### PR TITLE
Add GitHub Actions workflow to build APK on push or manual trigger

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,34 @@
+name: Build APK
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: 8.7
+
+      - name: Build debug APK
+        run: gradle :app:assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          retention-days: 1


### PR DESCRIPTION
### Motivation
- Provide a CI workflow that builds the Android app APK on every `push` and on-demand, and make the generated APK available as a short-lived artifact.

### Description
- Add `.github/workflows/build-apk.yml` which triggers on `push` and `workflow_dispatch`, sets up JDK 17 via `actions/setup-java@v5` and Gradle via `gradle/actions/setup-gradle@v4`, runs `gradle :app:assembleDebug`, and uploads `app/build/outputs/apk/debug/*.apk` as an artifact with `retention-days: 1`.

### Testing
- Ran the repository check script via `scripts/check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8106ed7f083218c3ceb9b6fdbd8c5)