### PR TITLE
Escape JSON hint in activity_main.xml to fix resource parsing

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -246,7 +246,7 @@
                     android:layout_height="180dp"
                     android:layout_marginTop="8dp"
                     android:gravity="top|start"
-                    android:hint="{\"spotifyShuffler.items\":\"[...]\"}"
+                    android:hint="{&quot;spotifyShuffler.items&quot;:&quot;[...]&quot;}"
                     android:inputType="textMultiLine"
                     android:scrollbars="vertical" />
             </LinearLayout>


### PR DESCRIPTION
### Motivation
- Fix an XML parse error in `app/src/main/res/layout/activity_main.xml` where a raw JSON string in `android:hint` caused `./gradlew check` to fail during resource parsing.

### Description
- Replace raw double quotes in the `android:hint` of `@+id/storageJsonInput` with XML entities (`&quot;`) so the layout XML is well-formed.

### Testing
- Ran `./gradlew check` before the change which failed with an XML parse error, then ran it after the change where resource parsing succeeded but the build subsequently failed due to a network/repository error downloading `com.android.tools.build:aapt2` (HTTP 403), so no further code changes were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c865153730832195ca169eb480b91c)