### PR TITLE
Add GitHub Actions workflow to build and upload debug APK

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,29 @@
+name: Build APK
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          retention-days: 1

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
### Motivation
- Provide an automated CI workflow to produce an APK on every push and on-demand via manual dispatch. 
- Preserve build outputs by uploading the generated APK as an artifact with a short retention to simplify sharing and debugging.

### Description
- Add a new workflow file at `./github/workflows/build-apk.yml` that triggers on `push` and `workflow_dispatch`.
- Configure the job to run on `ubuntu-latest` and set up JDK 17 using `actions/setup-java@v5` with `distribution: temurin`.
- Run the debug build with `./gradlew assembleDebug` and upload produced APK(s) from `app/build/outputs/apk/debug/*.apk` using `actions/upload-artifact@v4`.
- Set the uploaded artifact name to `app-debug-apk` and `retention-days` to `1`.

### Testing
- Run `./gradlew check` locally and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8693837248321b562ef6a98ec8c96)