### PR TITLE
Replace launcher icon with black circle

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,9 +5,9 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@drawable/ic_launcher_foreground"
+        android:icon="@mipmap/ic_launcher"
         android:label="Shuffle By Album"
-        android:roundIcon="@drawable/ic_launcher_foreground"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ShuffleByAlbum">
         <activity

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#191414" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <solid android:color="#191414" />
+    <solid android:color="#FFFFFF" />
 </shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1DB954"
-        android:pathData="M54,10A44,44 0 1,1 54,98A44,44 0 1,1 54,10z" />
+        android:pathData="M54,21A33,33 0 1,1 54,87A33,33 0 1,1 54,21z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,9 +4,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#191414"
-        android:pathData="M0,0h108v108h-108z" />
-    <path
         android:fillColor="#1DB954"
         android:pathData="M54,10A44,44 0 1,1 54,98A44,44 0 1,1 54,10z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,8 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1DB954"
-        android:pathData="M10,10h88v88h-88z" />
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M30,37c19,-10 32,-7 48,2l-4,6c-16,-8 -26,-10 -41,-2zM30,52c18,-8 30,-6 44,2l-4,6c-14,-6 -24,-8 -38,-2zM30,66c12,-5 22,-4 32,2l-4,6c-9,-4 -16,-5 -26,-1z" />
+        android:pathData="M54,10A44,44 0 1,1 54,98A44,44 0 1,1 54,10z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1DB954"
-        android:pathData="M54,10A44,44 0 1,1 54,98A44,44 0 1,1 54,10z" />
+        android:pathData="M54,0A54,54 0 1,1 54,108A54,54 0 1,1 54,0z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1ED760"
-        android:pathData="M54,24A30,30 0 1,1 54,84A30,30 0 1,1 54,24z" />
+        android:pathData="M54,29A25,25 0 1,1 54,79A25,25 0 1,1 54,29z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1ED760"
-        android:pathData="M54,29A25,25 0 1,1 54,79A25,25 0 1,1 54,29z" />
+        android:pathData="M54,32A22,22 0 1,1 54,76A22,22 0 1,1 54,32z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#1ED760"
-        android:pathData="M54,32A22,22 0 1,1 54,76A22,22 0 1,1 54,32z" />
+        android:pathData="M54,26A28,28 0 1,1 54,82A28,28 0 1,1 54,26z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,6 +4,9 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
+        android:fillColor="#191414"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
         android:fillColor="#1DB954"
-        android:pathData="M54,0A54,54 0 1,1 54,108A54,54 0 1,1 54,0z" />
+        android:pathData="M54,10A44,44 0 1,1 54,98A44,44 0 1,1 54,10z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#1DB954"
-        android:pathData="M54,21A33,33 0 1,1 54,87A33,33 0 1,1 54,21z" />
+        android:fillColor="#1ED760"
+        android:pathData="M54,24A30,30 0 1,1 54,84A30,30 0 1,1 54,24z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#1ED760"
+        android:fillColor="#000000"
         android:pathData="M54,26A28,28 0 1,1 54,82A28,28 0 1,1 54,26z" />
 </vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
### Motivation
- Simplify the app launcher artwork by replacing the existing vector artwork with a single black circle.

### Description
- Updated `app/src/main/res/drawable/ic_launcher_foreground.xml` to a single vector path drawing a circle filled with black and removed the previous white glyph paths.

### Testing
- Ran `./gradlew check` which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8737b584883218965f98c5b7ac3cb)