### PR TITLE
Upgrade Android Gradle plugin to 8.7.3, Kotlin to 2.0.21, and Gradle wrapper to 8.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.5.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Motivation
- Update build tooling to newer versions for compatibility, bug fixes, and access to recent features in Android Gradle Plugin, Kotlin, and Gradle.

### Description
- Bump `com.android.application` plugin from `8.5.2` to `8.7.3` in `build.gradle.kts`.
- Bump `org.jetbrains.kotlin.android` plugin from `1.9.24` to `2.0.21` in `build.gradle.kts`.
- Update Gradle wrapper `distributionUrl` from `gradle-8.7-bin.zip` to `gradle-8.9-bin.zip` in `gradle/wrapper/gradle-wrapper.properties`.

### Testing
- Ran `./gradlew --version` to confirm the wrapper points to Gradle `8.9` and it reported the expected version.
- Executed `./gradlew build` and the project build and unit tests completed successfully in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cac3778658832180357f0b0c1865da)