### PR TITLE
Disable autofill for URI/JSON inputs and restore Autofill lint checks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,6 @@ android {
         warningsAsErrors = true
         abortOnError = true
         disable += setOf(
-            "Autofill",
             "ButtonStyle",
             "GradleDependency",
             "HardcodedText",

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -96,7 +96,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    android:hint="spotify:album:... or spotify:playlist:..." />
+                    android:hint="spotify:album:... or spotify:playlist:..."
+                    android:importantForAutofill="no" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -248,7 +249,8 @@
                     android:gravity="top|start"
                     android:hint="{&quot;spotifyShuffler.items&quot;:&quot;[...]&quot;}"
                     android:inputType="textMultiLine"
-                    android:scrollbars="vertical" />
+                    android:scrollbars="vertical"
+                    android:importantForAutofill="no" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>


### PR DESCRIPTION
### Motivation
- Prevent platform autofill from populating the free-form URI and JSON text inputs and re-enable the Autofill lint so the project is checked for related issues.

### Description
- Add `android:importantForAutofill="no"` to `@id/itemUriInput` and `@id/storageJsonInput` in `app/src/main/res/layout/activity_main.xml` to opt those EditText fields out of autofill.
- Remove `"Autofill"` from the `android.lint.disable` set in `app/build.gradle.kts` so Autofill lint checks are active again.

### Testing
- Attempted to run `./gradlew lint check` to validate no Autofill warnings remain, but the run failed due to the Gradle wrapper download being blocked by the environment proxy (`HTTP/1.1 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc5cf0b5cc8321879810beb4ec27ae)