### PR TITLE
Remove unused resources and refresh lint baseline

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -31,28 +31,6 @@
     </issue>
 
     <issue
-        id="UnusedResources"
-        message="The resource `R.color.surface` appears to be unused"
-        errorLine1="    &lt;color name=&quot;surface&quot;>#FFFCFF&lt;/color>"
-        errorLine2="           ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/colors.xml"
-            line="6"
-            column="12"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.app_name` appears to be unused"
-        errorLine1="    &lt;string name=&quot;app_name&quot;>Shuffle By Album&lt;/string>"
-        errorLine2="            ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="3"
-            column="13"/>
-    </issue>
-
-    <issue
         id="MonochromeLauncherIcon"
         message="The application adaptive icon is missing a monochrome tag"
         errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,5 +3,4 @@
     <color name="purple_500">#6750A4</color>
     <color name="purple_700">#4F378B</color>
     <color name="teal_200">#03DAC5</color>
-    <color name="surface">#FFFCFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_name">Shuffle By Album</string>
-</resources>


### PR DESCRIPTION
### Motivation
- Remove the resources that were causing baselined `UnusedResources` lint issues and update the lint baseline to reflect their removal.

### Description
- Deleted `app/src/main/res/values/strings.xml` (unused `app_name`) and removed the `surface` color from `app/src/main/res/values/colors.xml`, then regenerated `app/lint-baseline.xml` to drop the corresponding `UnusedResources` entries.

### Testing
- Ran `./gradlew :app:updateLintBaseline` which completed successfully and updated `app/lint-baseline.xml`, and ran `./gradlew check` which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc6ccbce148321a143e41c0edbaa8d)