### PR TITLE
Add monochrome adaptive icons, move mipmap resources, and update lint baseline

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -24,35 +24,6 @@
     </issue>
 
     <issue
-        id="ObsoleteSdkInt"
-        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 26. Merge all the resources in this folder into `mipmap-anydpi`.">
-        <location
-            file="src/main/res/mipmap-anydpi-v26"/>
-    </issue>
-
-    <issue
-        id="MonochromeLauncherIcon"
-        message="The application adaptive icon is missing a monochrome tag"
-        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
-        errorLine2="^">
-        <location
-            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
-            line="2"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="MonochromeLauncherIcon"
-        message="The application adaptive roundIcon is missing a monochrome tag"
-        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
-        errorLine2="^">
-        <location
-            file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
-            line="2"
-            column="1"/>
-    </issue>
-
-    <issue
         id="ButtonStyle"
         message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
         errorLine1="                    &lt;Button"

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap/ic_launcher.xml
+++ b/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
### Motivation

- Ensure adaptive launcher icons include a monochrome declaration to satisfy modern Android lint checks and requirements.
- Remove the obsolete `mipmap-anydpi-v26` folder usage by consolidating resources into `mipmap-anydpi` and adding root `mipmap` entries to simplify resource qualifiers.
- Keep the lint baseline in sync with resource changes so the project no longer records obsolete `ObsoleteSdkInt` and `MonochromeLauncherIcon` warnings.

### Description

- Added a `<monochrome android:drawable="@drawable/ic_launcher_foreground" />` element to the adaptive icon XML files to provide monochrome icons for supported launchers in `app/src/main/res/mipmap-anydpi/ic_launcher.xml` and `app/src/main/res/mipmap-anydpi/ic_launcher_round.xml`.
- Renamed/moved the previous `mipmap-anydpi-v26` icon files into `mipmap-anydpi` and added new copies in the `mipmap` folder at `app/src/main/res/mipmap/ic_launcher.xml` and `app/src/main/res/mipmap/ic_launcher_round.xml` to cover the non-v26 mipmap folder.
- Updated `app/lint-baseline.xml` to remove entries related to the removed `mipmap-anydpi-v26` folder and the `MonochromeLauncherIcon` and `ObsoleteSdkInt` baseline issues.

### Testing

- Ran `./gradlew lint` and confirmed the updated lint baseline no longer reports the removed `MonochromeLauncherIcon` and `ObsoleteSdkInt` issues and the task completed successfully.
- Ran `./gradlew assembleDebug` to verify resources package correctly and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc710df5d0832195f16e9acb3f277d)