### PR TITLE
Convert action row Buttons to MaterialButton styles

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -23,49 +23,9 @@
             column="9"/>
     </issue>
 
-    <issue
-        id="ButtonStyle"
-        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
-        errorLine1="                    &lt;Button"
-        errorLine2="                     ~~~~~~">
-        <location
-            file="src/main/res/layout/activity_main.xml"
-            line="50"
-            column="22"/>
-    </issue>
 
-    <issue
-        id="ButtonStyle"
-        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
-        errorLine1="                    &lt;Button"
-        errorLine2="                     ~~~~~~">
-        <location
-            file="src/main/res/layout/activity_main.xml"
-            line="108"
-            column="22"/>
-    </issue>
 
-    <issue
-        id="ButtonStyle"
-        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
-        errorLine1="                    &lt;Button"
-        errorLine2="                     ~~~~~~">
-        <location
-            file="src/main/res/layout/activity_main.xml"
-            line="157"
-            column="22"/>
-    </issue>
 
-    <issue
-        id="ButtonStyle"
-        message="Buttons in button bars should be borderless; use `style=&quot;?android:attr/buttonBarButtonStyle&quot;` (and `?android:attr/buttonBarStyle` on the parent)"
-        errorLine1="                    &lt;Button"
-        errorLine2="                     ~~~~~~">
-        <location
-            file="src/main/res/layout/activity_main.xml"
-            line="227"
-            column="22"/>
-    </issue>
 
     <issue
         id="TextFields"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -47,16 +47,17 @@
                     android:layout_marginTop="8dp"
                     android:orientation="horizontal">
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
+                        style="@style/Widget.MaterialComponents.Button"
                         android:id="@+id/loginButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="Connect" />
 
-                    <Button
-                        android:id="@+id/logoutButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/logoutButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
@@ -105,16 +106,17 @@
                     android:layout_marginTop="8dp"
                     android:orientation="horizontal">
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
+                        style="@style/Widget.MaterialComponents.Button"
                         android:id="@+id/addButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="Add" />
 
-                    <Button
-                        android:id="@+id/importPlaylistButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/importPlaylistButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
@@ -154,32 +156,33 @@
                     android:layout_marginTop="8dp"
                     android:orientation="horizontal">
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
+                        style="@style/Widget.MaterialComponents.Button"
                         android:id="@+id/startButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="Start" />
 
-                    <Button
-                        android:id="@+id/reattachButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/reattachButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
                         android:text="Reattach"
                         android:visibility="gone" />
 
-                    <Button
-                        android:id="@+id/skipButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/skipButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
                         android:text="Skip" />
 
-                    <Button
-                        android:id="@+id/stopButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/stopButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"
@@ -224,16 +227,17 @@
                     android:layout_marginTop="8dp"
                     android:orientation="horizontal">
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
+                        style="@style/Widget.MaterialComponents.Button"
                         android:id="@+id/exportStorageButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
                         android:text="Export JSON" />
 
-                    <Button
-                        android:id="@+id/importStorageButton"
+                    <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:id="@+id/importStorageButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="8dp"


### PR DESCRIPTION
### Motivation
- Modernize the UI action rows to use Material Components so button appearance and theming are consistent across devices.
- Remove the lint suppression entries for `ButtonStyle` by addressing the root cause in the layout rather than keeping baseline exceptions.

### Description
- Replaced plain `<Button>` controls in `app/src/main/res/layout/activity_main.xml` action rows with `com.google.android.material.button.MaterialButton` while preserving all existing IDs and sizing (`0dp + layout_weight` and `wrap_content`).
- Applied a consistent primary contained Material style (`@style/Widget.MaterialComponents.Button`) to primary actions (`Connect`, `Add`, `Start`, `Export JSON`).
- Converted secondary actions (`Disconnect`, `Import Albums`, `Reattach`, `Skip`, `Stop`, `Import JSON`) to the Material outlined style (`@style/Widget.MaterialComponents.Button.OutlinedButton`).
- Removed the now-obsolete `ButtonStyle` issues from `app/lint-baseline.xml` so the baseline no longer suppresses those warnings.

### Testing
- Ran `./gradlew lint` which completed successfully without reintroducing `ButtonStyle` baseline entries.
- Ran `./gradlew check` which completed successfully (build and checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ccaa7989e08321b20ea30ca1f3297d)