### PR TITLE
Improve URI input keyboard options and refresh lint baseline

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -23,19 +23,4 @@
             column="9"/>
     </issue>
 
-
-
-
-
-    <issue
-        id="TextFields"
-        message="This text field does not specify an `inputType`"
-        errorLine1="                &lt;EditText"
-        errorLine2="                 ~~~~~~~~">
-        <location
-            file="src/main/res/layout/activity_main.xml"
-            line="94"
-            column="18"/>
-    </issue>
-
 </issues>

--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Base64
+import android.view.inputmethod.EditorInfo
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -133,6 +134,14 @@ class MainActivity : AppCompatActivity() {
             toast("Disconnected from Spotify.")
         }
         addButton.setOnClickListener { appScope.launch { addItem() } }
+        itemUriInput.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                addButton.performClick()
+                true
+            } else {
+                false
+            }
+        }
         importPlaylistButton.setOnClickListener { appScope.launch { importAlbumsFromPlaylist() } }
         startButton.setOnClickListener { appScope.launch { startShuffleSession() } }
         reattachButton.setOnClickListener { appScope.launch { reattachSession() } }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -98,7 +98,9 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:hint="spotify:album:... or spotify:playlist:..."
-                    android:importantForAutofill="no" />
+                    android:importantForAutofill="no"
+                    android:imeOptions="actionDone"
+                    android:inputType="textUri" />
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
### Motivation
- Improve keyboard UX for the album/playlist URI input and satisfy lint by specifying an `inputType` for the text field.

### Description
- Added `android:inputType="textUri"` and `android:imeOptions="actionDone"` to the `EditText` with `@id/itemUriInput` in `app/src/main/res/layout/activity_main.xml` while keeping `hint` and `importantForAutofill` unchanged.
- Regenerated the app lint baseline (`app/lint-baseline.xml`) so the previous `TextFields` baseline entry for this layout location is removed.

### Testing
- Ran `./gradlew app:updateLintBaseline` which completed and updated the baseline to remove the `TextFields` entry for this layout location. (Succeeded.)
- Ran `./gradlew check` which completed successfully with the build passing. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ccaf33fccc83218b3e41e6901e6a7c)