### PR TITLE
Consolidate signing configuration into single `env` signingConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,13 +21,7 @@ android {
     }
 
     signingConfigs {
-        getByName("debug") {
-            storeFile = System.getenv("SIGNING_STORE_FILE")?.let(::file)
-            storePassword = System.getenv("SIGNING_STORE_PASSWORD")
-            keyAlias = System.getenv("SIGNING_KEY_ALIAS")
-            keyPassword = System.getenv("SIGNING_KEY_PASSWORD")
-        }
-        create("release") {
+        create("env") {
             storeFile = System.getenv("SIGNING_STORE_FILE")?.let(::file)
             storePassword = System.getenv("SIGNING_STORE_PASSWORD")
             keyAlias = System.getenv("SIGNING_KEY_ALIAS")
@@ -37,10 +31,10 @@ android {
 
     buildTypes {
         debug {
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("env")
         }
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.getByName("env")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
### Motivation

- Simplify signing configuration by centralizing environment-based keystore properties into a single signing config.

### Description

- Replace separate `debug` and `release` signing config definitions with a single `env` signing config that reads keystore properties from environment variables.
- Update both `debug` and `release` build types to reference `signingConfigs.getByName("env")` instead of separate configs.
- No other build settings or proguard rules were changed.

### Testing

- Ran `./gradlew assembleDebug` which completed successfully using the `env` signing config.
- Ran `./gradlew assembleRelease` which completed successfully using the `env` signing config.
- Ran `./gradlew lint` which completed successfully with the existing lint configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cdaae2ac1883218196f4fb51cb6737)