### PR TITLE
Add composite action to build signed APK and simplify workflow

### DIFF
--- a/.github/actions/build-signed-apk/action.yml
+++ b/.github/actions/build-signed-apk/action.yml
@@ -1,0 +1,132 @@
+name: Build Signed APK
+
+description: Validate signing inputs, build an APK variant, and upload it as an artifact.
+
+inputs:
+  variant:
+    description: APK variant to build (debug or release)
+    required: true
+  keystore_base64:
+    description: Base64-encoded signing keystore content
+    required: true
+  keystore_password:
+    description: Keystore password
+    required: true
+  key_alias:
+    description: Signing key alias
+    required: true
+  key_password:
+    description: Signing key password (optional for PKCS12 keystores)
+    required: false
+    default: ''
+  artifact_name:
+    description: Uploaded artifact name
+    required: true
+  artifact_path:
+    description: Glob/path for APK artifact upload
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate required signing inputs
+      shell: bash
+      env:
+        INPUT_VARIANT: ${{ inputs.variant }}
+        INPUT_KEYSTORE_BASE64: ${{ inputs.keystore_base64 }}
+        INPUT_KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
+        INPUT_KEY_ALIAS: ${{ inputs.key_alias }}
+        INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        INPUT_ARTIFACT_PATH: ${{ inputs.artifact_path }}
+      run: |
+        set -euo pipefail
+
+        if [ "$INPUT_VARIANT" != "debug" ] && [ "$INPUT_VARIANT" != "release" ]; then
+          echo "Input 'variant' must be either 'debug' or 'release'."
+          exit 1
+        fi
+
+        for required_input in INPUT_KEYSTORE_BASE64 INPUT_KEYSTORE_PASSWORD INPUT_KEY_ALIAS INPUT_ARTIFACT_NAME INPUT_ARTIFACT_PATH; do
+          if [ -z "${!required_input}" ]; then
+            echo "Missing required input: ${required_input#INPUT_}"
+            exit 1
+          fi
+        done
+
+    - name: Decode keystore
+      shell: bash
+      env:
+        KEYSTORE_BASE64: ${{ inputs.keystore_base64 }}
+        KEYSTORE_PATH: ${{ runner.temp }}/${{ inputs.variant }}-signing.jks
+      run: |
+        set -euo pipefail
+        printf %s "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+
+    - name: Validate keystore alias exists
+      shell: bash
+      env:
+        KEYSTORE_PATH: ${{ runner.temp }}/${{ inputs.variant }}-signing.jks
+        KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
+        KEY_ALIAS: ${{ inputs.key_alias }}
+      run: |
+        set -euo pipefail
+        keytool -list \
+          -keystore "$KEYSTORE_PATH" \
+          -storepass "$KEYSTORE_PASSWORD" \
+          -alias "$KEY_ALIAS"
+
+    - name: Validate alias type is PrivateKeyEntry
+      shell: bash
+      env:
+        KEYSTORE_PATH: ${{ runner.temp }}/${{ inputs.variant }}-signing.jks
+        KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
+        KEY_ALIAS: ${{ inputs.key_alias }}
+      run: |
+        set -euo pipefail
+        entry_type="$(keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" | awk -F': ' '/Entry type:/{print $2; exit}')"
+        if [ "$entry_type" != "PrivateKeyEntry" ]; then
+          echo "Alias '$KEY_ALIAS' is '$entry_type', but APK signing requires a PrivateKeyEntry."
+          echo "Available aliases in keystore:"
+          keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Alias name:|Entry type:/{print $1\": \"$2}'
+          exit 1
+        fi
+
+    - name: Resolve key password for keystore type
+      shell: bash
+      env:
+        KEYSTORE_PATH: ${{ runner.temp }}/${{ inputs.variant }}-signing.jks
+        KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
+        KEY_PASSWORD: ${{ inputs.key_password }}
+      run: |
+        set -euo pipefail
+        keystore_type="$(keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Keystore type:/{print $2; exit}')"
+        if [ "$keystore_type" = "PKCS12" ]; then
+          echo "Using keystore password as key password for PKCS12 keystore."
+          echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
+        else
+          if [ -z "$KEY_PASSWORD" ]; then
+            echo "Input 'key_password' is required for non-PKCS12 keystores."
+            exit 1
+          fi
+          echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
+        fi
+
+    - name: Build APK
+      shell: bash
+      env:
+        SIGNING_STORE_FILE: ${{ runner.temp }}/${{ inputs.variant }}-signing.jks
+        SIGNING_STORE_PASSWORD: ${{ inputs.keystore_password }}
+        SIGNING_KEY_ALIAS: ${{ inputs.key_alias }}
+        SIGNING_KEY_PASSWORD: ${{ env.EFFECTIVE_SIGNING_KEY_PASSWORD }}
+      run: |
+        set -euo pipefail
+        variant_capitalized="${{ inputs.variant }}"
+        variant_capitalized="${variant_capitalized^}"
+        ./gradlew --no-daemon "assemble${variant_capitalized}"
+
+    - name: Upload APK artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path }}
+        retention-days: 1

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -41,87 +41,16 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Validate debug signing secrets
-        env:
-          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-          DEBUG_KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
-          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          for required_secret in DEBUG_KEYSTORE_BASE64 DEBUG_KEYSTORE_PASSWORD DEBUG_KEY_ALIAS; do
-            if [ -z "${!required_secret}" ]; then
-              echo "Missing required secret: ${required_secret}"
-              exit 1
-            fi
-          done
-
-      - name: Decode debug keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-        run: |
-          set -euo pipefail
-          printf %s "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/debug-signing.jks"
-
-      - name: Validate debug keystore entry
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/debug-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          keytool -list \
-            -keystore "$KEYSTORE_PATH" \
-            -storepass "$KEYSTORE_PASSWORD" \
-            -alias "$KEY_ALIAS"
-
-      - name: Validate debug signing alias type
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/debug-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          entry_type="$(keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" | awk -F': ' '/Entry type:/{print $2; exit}')"
-          if [ "$entry_type" != "PrivateKeyEntry" ]; then
-            echo "Alias '$KEY_ALIAS' is '$entry_type', but APK signing requires a PrivateKeyEntry."
-            echo "Available aliases in keystore:"
-            keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Alias name:|Entry type:/{print $1\": \"$2}'
-            exit 1
-          fi
-
-      - name: Resolve debug key password for keystore type
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/debug-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
-          KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          keystore_type="$(keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Keystore type:/{print $2; exit}')"
-          if [ "$keystore_type" = "PKCS12" ]; then
-            echo "Using keystore password as key password for PKCS12 keystore."
-            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
-          else
-            if [ -z "$KEY_PASSWORD" ]; then
-              echo "DEBUG_KEY_PASSWORD is required for non-PKCS12 keystores."
-              exit 1
-            fi
-            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
-          fi
-
-      - name: Build debug APK
-        env:
-          SIGNING_STORE_FILE: ${{ runner.temp }}/debug-signing.jks
-          SIGNING_STORE_PASSWORD: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
-          SIGNING_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ env.EFFECTIVE_SIGNING_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon assembleDebug
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v6
+      - name: Build signed debug APK
+        uses: ./.github/actions/build-signed-apk
         with:
-          name: app-debug-apk-${{ github.run_id }}
-          path: app/build/outputs/apk/debug/*.apk
-          retention-days: 1
+          variant: debug
+          keystore_base64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+          keystore_password: ${{ secrets.DEBUG_KEYSTORE_PASSWORD }}
+          key_alias: ${{ secrets.DEBUG_KEY_ALIAS }}
+          key_password: ${{ secrets.DEBUG_KEY_PASSWORD }}
+          artifact_name: app-debug-apk-${{ github.run_id }}
+          artifact_path: app/build/outputs/apk/debug/*.apk
 
   release-build:
     # Route release builds to main pushes, or manual runs that choose release on the main branch only.
@@ -151,84 +80,13 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Validate release signing secrets
-        env:
-          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          for required_secret in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
-            if [ -z "${!required_secret}" ]; then
-              echo "Missing required secret: ${required_secret}"
-              exit 1
-            fi
-          done
-
-      - name: Decode release keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-        run: |
-          set -euo pipefail
-          printf %s "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-signing.jks"
-
-      - name: Validate release keystore entry
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/release-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          keytool -list \
-            -keystore "$KEYSTORE_PATH" \
-            -storepass "$KEYSTORE_PASSWORD" \
-            -alias "$KEY_ALIAS"
-
-      - name: Validate release signing alias type
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/release-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          entry_type="$(keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" | awk -F': ' '/Entry type:/{print $2; exit}')"
-          if [ "$entry_type" != "PrivateKeyEntry" ]; then
-            echo "Alias '$KEY_ALIAS' is '$entry_type', but APK signing requires a PrivateKeyEntry."
-            echo "Available aliases in keystore:"
-            keytool -list -v -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Alias name:|Entry type:/{print $1\": \"$2}'
-            exit 1
-          fi
-
-      - name: Resolve release key password for keystore type
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/release-signing.jks
-          KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          keystore_type="$(keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Keystore type:/{print $2; exit}')"
-          if [ "$keystore_type" = "PKCS12" ]; then
-            echo "Using keystore password as key password for PKCS12 keystore."
-            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
-          else
-            if [ -z "$KEY_PASSWORD" ]; then
-              echo "RELEASE_KEY_PASSWORD is required for non-PKCS12 keystores."
-              exit 1
-            fi
-            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
-          fi
-
-      - name: Build release APK
-        env:
-          SIGNING_STORE_FILE: ${{ runner.temp }}/release-signing.jks
-          SIGNING_STORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-          SIGNING_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ env.EFFECTIVE_SIGNING_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon assembleRelease
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v6
+      - name: Build signed release APK
+        uses: ./.github/actions/build-signed-apk
         with:
-          name: app-release-apk-${{ github.run_id }}
-          path: app/build/outputs/apk/release/*.apk
-          retention-days: 1
+          variant: release
+          keystore_base64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          keystore_password: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          key_alias: ${{ secrets.RELEASE_KEY_ALIAS }}
+          key_password: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          artifact_name: app-release-apk-${{ github.run_id }}
+          artifact_path: app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
### Motivation
- Remove duplicated signing, keystore handling, and artifact upload shell logic from workflow jobs to improve maintainability and reduce risk of drift. 
- Provide a single, reusable composite action to centralize validation, keystore decoding, and Gradle invocation so `debug` and `release` builds behave consistently.

### Description
- Add a new composite action at `./.github/actions/build-signed-apk/action.yml` that accepts `variant`, `keystore_base64`, `keystore_password`, `key_alias`, optional `key_password`, `artifact_name`, and `artifact_path` and performs input validation, keystore decode to `$RUNNER_TEMP/<variant>-signing.jks`, alias existence/type checks with `keytool`, PKCS12 key-password fallback, `./gradlew --no-daemon assemble<Variant>`, and artifact upload via `actions/upload-artifact@v6`.
- Replace the previous per-job shell steps in `./.github/workflows/build-apk.yml` with a single `uses: ./.github/actions/build-signed-apk` step in both `debug-build` and `release-build` jobs while keeping the setup steps (`checkout`, `setup-java`, `setup-android`).
- Wire job-specific secrets and inputs into the action (`DEBUG_*` and `RELEASE_*` secrets) and preserve per-run artifact naming and paths.
- Commit includes the new action file and the simplified workflow file.

### Testing
- Ran `./gradlew check` and it completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cdac90282c8321a17a77cfed2e2803)