### PR TITLE
Simplify keystore setup and key-password resolution in CI workflow

### DIFF
--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -90,32 +90,22 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Decode keystore
+      - name: Set up keystore
         env:
           KEYSTORE_BASE64: ${{ env.KEYSTORE_BASE64 }}
           KEYSTORE_PATH: ${{ runner.temp }}/${{ env.KEYSTORE_FILENAME }}
+          KEYSTORE_PASSWORD: ${{ env.KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ env.KEY_PASSWORD }}
         run: |
           set -euo pipefail
           printf %s "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
 
-      - name: Resolve key password for keystore type
-        env:
-          KEYSTORE_PATH: ${{ runner.temp }}/${{ env.KEYSTORE_FILENAME }}
-          KEYSTORE_PASSWORD: ${{ env.KEYSTORE_PASSWORD }}
-          KEY_PASSWORD: ${{ env.KEY_PASSWORD }}
-          VARIANT: ${{ inputs.variant }}
-        run: |
-          set -euo pipefail
-          keystore_type="$(keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" | awk -F': ' '/Keystore type:/{print $2; exit}')"
-          if [ "$keystore_type" = "PKCS12" ]; then
-            echo "Using keystore password as key password for PKCS12 keystore."
-            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
-          else
-            if [ -z "$KEY_PASSWORD" ]; then
-              echo "KEY_PASSWORD is required for non-PKCS12 keystores (${VARIANT})."
-              exit 1
-            fi
+          if [ -n "$KEY_PASSWORD" ]; then
+            echo "Using provided key password."
             echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
+          else
+            echo "KEY_PASSWORD not set. Falling back to keystore password."
+            echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           fi
 
       - name: Build APK

--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -101,10 +101,10 @@ jobs:
           printf %s "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
 
           if [ -n "$KEY_PASSWORD" ]; then
-            echo "Using provided key password."
+            echo "Using KEY_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
             echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
           else
-            echo "KEY_PASSWORD not set. Falling back to keystore password."
+            echo "KEY_PASSWORD not set. Using KEYSTORE_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
             echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -96,15 +96,17 @@ jobs:
           KEYSTORE_PATH: ${{ runner.temp }}/${{ env.KEYSTORE_FILENAME }}
           KEYSTORE_PASSWORD: ${{ env.KEYSTORE_PASSWORD }}
           KEY_PASSWORD: ${{ env.KEY_PASSWORD }}
+          VARIANT: ${{ inputs.variant }}
         run: |
           set -euo pipefail
           printf %s "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+          variant_upper="$(printf '%s' "$VARIANT" | tr '[:lower:]' '[:upper:]')"
 
           if [ -n "$KEY_PASSWORD" ]; then
-            echo "Using KEY_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
+            echo "Using ${variant_upper}_KEY_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
             echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEY_PASSWORD" >> "$GITHUB_ENV"
           else
-            echo "KEY_PASSWORD not set. Using KEYSTORE_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
+            echo "${variant_upper}_KEY_PASSWORD not set. Using ${variant_upper}_KEYSTORE_PASSWORD for EFFECTIVE_SIGNING_KEY_PASSWORD."
             echo "EFFECTIVE_SIGNING_KEY_PASSWORD=$KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
### Motivation
- Simplify and consolidate keystore decoding and key password resolution into a single workflow step.
- Remove dependency on `keytool` detection of keystore type and avoid failing when `KEY_PASSWORD` is not provided.
- Provide a sensible fallback by using the keystore password as the signing key password when `KEY_PASSWORD` is absent.

### Description
- Renamed the step `Decode keystore` to `Set up keystore` and moved the base64 decoding into that step so the keystore file is created where it is needed.
- Removed the `keytool` PKCS12 type check and the requirement to error out for non-PKCS12 keystores, replacing it with a simple conditional that uses `KEY_PASSWORD` if set or falls back to `KEYSTORE_PASSWORD` otherwise.
- Set `EFFECTIVE_SIGNING_KEY_PASSWORD` in the environment based on the new logic and simplified the step inputs/vars accordingly.
- Kept the subsequent `Build APK` and `Upload APK artifact` steps unchanged aside from using the computed `EFFECTIVE_SIGNING_KEY_PASSWORD`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce9865f1f8832199b12ee241c0ddf6)