### PR TITLE
Name APK artifact as app-<variant>-<runId>.apk and set app versionName to run ID

### DIFF
--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -40,8 +40,8 @@ jobs:
 
           echo "KEYSTORE_FILENAME=${VARIANT}-signing.jks" >> "$GITHUB_ENV"
           echo "GRADLE_TASK=assemble${variant_capitalized}" >> "$GITHUB_ENV"
-          echo "ARTIFACT_NAME=app-${VARIANT}-apk-${RUN_ID}" >> "$GITHUB_ENV"
-          echo "ARTIFACT_PATH=app/build/outputs/apk/${VARIANT}/*.apk" >> "$GITHUB_ENV"
+          echo "APK_FILENAME=app-${VARIANT}-${RUN_ID}.apk" >> "$GITHUB_ENV"
+          echo "ARTIFACT_NAME=app-${VARIANT}-${RUN_ID}" >> "$GITHUB_ENV"
 
           variant_upper="$(printf '%s' "$VARIANT" | tr '[:lower:]' '[:upper:]')"
 
@@ -116,7 +116,23 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ env.KEYSTORE_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ env.KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ env.EFFECTIVE_SIGNING_KEY_PASSWORD }}
-        run: ./gradlew --no-daemon ${{ env.GRADLE_TASK }}
+          APP_VERSION_NAME: ${{ github.run_id }}
+        run: ./gradlew --no-daemon -PappVersionName="${APP_VERSION_NAME}" ${{ env.GRADLE_TASK }}
+
+      - name: Prepare APK artifact payload
+        env:
+          VARIANT: ${{ inputs.variant }}
+          APK_FILENAME: ${{ env.APK_FILENAME }}
+        run: |
+          set -euo pipefail
+          source_apk="$(find "app/build/outputs/apk/${VARIANT}" -maxdepth 1 -type f -name '*.apk' | head -n 1)"
+          if [ -z "$source_apk" ]; then
+            echo "No APK found for variant ${VARIANT}."
+            exit 1
+          fi
+
+          cp "$source_apk" "${RUNNER_TEMP}/${APK_FILENAME}"
+          echo "ARTIFACT_PATH=${RUNNER_TEMP}/${APK_FILENAME}" >> "$GITHUB_ENV"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v6

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,10 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "0.0.0"
+        versionName =
+            providers.gradleProperty("appVersionName")
+                .orElse("0.0.0")
+                .get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
### Motivation
- Ensure CI-produced debug APK is packaged with a run-specific filename (`app-debug-<runId>.apk`) instead of a zip containing `app-debug.apk` so artifacts are unambiguous and traceable.
- Use the CI run id as the app `versionName` so builds are identifiable by the run that produced them.

### Description
- Updated `.github/workflows/build-apk-common.yml` to set `APK_FILENAME=app-${VARIANT}-${RUN_ID}.apk` and `ARTIFACT_NAME=app-${VARIANT}-${RUN_ID}` during workflow resolution.
- Pass `github.run_id` into Gradle with `-PappVersionName="${APP_VERSION_NAME}"` during the build step so the produced APK can reflect the run id.
- Added a `Prepare APK artifact payload` step that locates the built APK, copies it to `${RUNNER_TEMP}/${APK_FILENAME}`, and sets `ARTIFACT_PATH` to that run-specific file for upload.
- Updated `app/build.gradle.kts` to read `versionName` from a Gradle property `appVersionName` with a fallback to `0.0.0`, allowing the CI `-PappVersionName` override to set the app version.

### Testing
- Ran `./gradlew check` locally and the build checks completed successfully (`BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cea5dd20388321b9b4bd707d66cc98)