### PR TITLE
Externalize app label, add debug app name and `.debug` applicationIdSuffix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     buildTypes {
         debug {
             signingConfig = signingConfigs.getByName("env")
+            applicationIdSuffix = ".debug"
         }
         release {
             signingConfig = signingConfigs.getByName("env")

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Shuffle By Album (Test)</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="Shuffle By Album"
+        android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ShuffleByAlbum">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Shuffle By Album</string>
+</resources>


### PR DESCRIPTION
### Motivation
- Make the app label localizable by moving the hardcoded label into string resources as `@string/app_name`.
- Provide a distinct debug app name to differentiate test/debug builds from release builds.
- Prevent installation conflicts between debug and release variants by adding a `.debug` app ID suffix for the debug build.

### Description
- Replaced hardcoded `android:label="Shuffle By Album"` in `AndroidManifest.xml` with `android:label="@string/app_name"`.
- Added `app/src/main/res/values/strings.xml` defining `app_name` as `Shuffle By Album`.
- Added `app/src/debug/res/values/strings.xml` overriding `app_name` for debug builds as `Shuffle By Album (Test)`.
- Updated `app/build.gradle.kts` to set `applicationIdSuffix = ".debug"` for the `debug` build type and left signing / other configs unchanged.

### Testing
- Ran `./gradlew assembleDebug` which completed successfully and produced a debug APK with the debug label and `.debug` application ID.
- Ran `./gradlew assembleRelease` which completed successfully and produced a release APK using the main `app_name`.
- Ran `./gradlew lint` which completed successfully with no new lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cebbe1dbb883219984519cacf108a6)