### PR TITLE
Update android-actions/setup-android to v4 in workflows

### DIFF
--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
+
       - name: Set up keystore
         env:
           KEYSTORE_BASE64: ${{ env.KEYSTORE_BASE64 }}

--- a/.github/workflows/build-apk-common.yml
+++ b/.github/workflows/build-apk-common.yml
@@ -95,8 +95,7 @@ jobs:
           cache: gradle
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
+        uses: android-actions/setup-android@v4
       - name: Set up keystore
         env:
           KEYSTORE_BASE64: ${{ env.KEYSTORE_BASE64 }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,5 +24,6 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
+
       - name: Run repository checks
         run: ./gradlew --no-daemon check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,6 @@ jobs:
           cache: gradle
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
+        uses: android-actions/setup-android@v4
       - name: Run repository checks
         run: ./gradlew --no-daemon check


### PR DESCRIPTION
### Motivation
- Upgrade the Android setup action to `android-actions/setup-android@v4` to ensure compatibility with newer runners and improved SDK setup.

### Description
- Replace `android-actions/setup-android@v3` with `android-actions/setup-android@v4` in `.github/workflows/build-apk-common.yml` and `.github/workflows/check.yml`.

### Testing
- No CI runs have been executed yet; the `check` workflow runs `./gradlew --no-daemon check` and the build workflow runs the APK build steps when triggered by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cec460e2c083219a18bf58cbb1d994)