### PR TITLE
Enable full javac lint (`-Xlint:all`) for JavaCompile

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:all")
     options.compilerArgs.add("-Werror")
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Java compiler emits a broader set of warnings so potential issues are caught by CI while continuing to fail the build on warnings.

### Description
- Add `-Xlint:all` to `options.compilerArgs` in `tasks.withType<JavaCompile>().configureEach` in `app/build.gradle.kts` while keeping the existing `-Werror` flag.

### Testing
- Ran `./gradlew check` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cecc19c6488321a74ae44d2467e4e4)