### PR TITLE
Add Detekt plugin dependency to root Gradle plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }


### PR DESCRIPTION
### Motivation
- Make the Detekt Gradle plugin available in the project so it can be enabled later while leaving it disabled for now.

### Description
- Add `id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false` to the root `build.gradle.kts` `plugins` block.

### Testing
- Ran `./gradlew check`, which failed to resolve the Detekt plugin artifact from the configured repositories (artifact fetch returned 403s in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cefadd3c6c8321addb0a843b3bc604)