### PR TITLE
Enable Detekt for all Kotlin and Kotlin script files, add config and baseline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,37 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+
 plugins {
+    base
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    allRules = true
+    config.setFrom(files("detekt.yml"))
+    baseline = file("detekt-baseline.xml")
+}
+
+tasks.withType<Detekt>().configureEach {
+    setSource(files(rootDir))
+    include("**/*.kt", "**/*.kts")
+    exclude("**/build/**", "**/.gradle/**")
+    reports {
+        html.required.set(true)
+        sarif.required.set(true)
+        md.required.set(true)
+    }
+}
+
+tasks.withType<DetektCreateBaselineTask>().configureEach {
+    setSource(files(rootDir))
+    include("**/*.kt", "**/*.kts")
+    exclude("**/build/**", "**/.gradle/**")
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("detekt"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.8" apply false
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues></CurrentIssues>
+</SmellBaseline>

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,14 @@
+build:
+  maxIssues: 0
+
+config:
+  validation: true
+
+processors:
+  active: true
+
+console-reports:
+  active: true
+
+output-reports:
+  active: true


### PR DESCRIPTION
### Motivation
- Add static analysis with Detekt across the whole repository to catch Kotlin issues and include Gradle Kotlin scripts (`*.kts`) in scans.
- Turn on all Detekt rules to maximize coverage while using a baseline to suppress existing issues.

### Description
- Enable the `io.gitlab.arturbosch.detekt` plugin in the root `build.gradle.kts`, add the `base` plugin to ensure lifecycle tasks are available, and configure `detekt { buildUponDefaultConfig = true; allRules = true; config.setFrom(files("detekt.yml")); baseline = file("detekt-baseline.xml") }`.
- Configure Detekt tasks to scan all `**/*.kt` and `**/*.kts` files, exclude build dirs, and enable `html`, `sarif`, and `md` reports; configure `DetektCreateBaselineTask` with the same sources.
- Wire Detekt into the `check` lifecycle by making `check` depend on `detekt` so analysis runs automatically as part of CI checks.
- Add `detekt.yml` (minimal config) and a placeholder `detekt-baseline.xml` baseline file in the project root.

### Testing
- Ran `./gradlew detekt` which failed to execute due to dependency resolution errors for `io.gitlab.arturbosch.detekt:detekt-cli:1.23.8` returning HTTP 403 from remote repositories in this environment.
- Ran `./gradlew check` which also failed for the same dependency-resolution issue, confirming Detekt is wired into `check` but cannot run here due to external repository access restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf001d30848321883cecc126ea98dd)