### PR TITLE
Use DiffUtil/ListAdapter for adapters and optimize queue updates

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="6" by="lint 8.7.3" type="baseline" client="gradle" dependencies="true" name="AGP (8.7.3)" variant="all" version="8.7.3">
 
-    <issue
-        id="NotifyDataSetChanged"
-        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
-        errorLine1="        notifyDataSetChanged()"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt"
-            line="822"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="NotifyDataSetChanged"
-        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
-        errorLine1="        notifyDataSetChanged()"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt"
-            line="859"
-            column="9"/>
-    </issue>
-
 </issues>

--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -125,6 +126,7 @@ class MainActivity : AppCompatActivity() {
         findViewById<RecyclerView>(R.id.queueRecycler).apply {
             layoutManager = LinearLayoutManager(this@MainActivity)
             adapter = queueAdapter
+            (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
         }
     }
 

--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -17,6 +17,8 @@ import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
@@ -822,13 +824,10 @@ data class SessionState(
 
 private class ItemAdapter(
     private val onRemove: (ShuffleItem) -> Unit,
-) : RecyclerView.Adapter<ItemAdapter.ItemViewHolder>() {
-    private val items = mutableListOf<ShuffleItem>()
+) : ListAdapter<ShuffleItem, ItemAdapter.ItemViewHolder>(ITEM_DIFF) {
 
     fun submit(next: List<ShuffleItem>) {
-        items.clear()
-        items.addAll(next)
-        notifyDataSetChanged()
+        submitList(next.toList())
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
@@ -836,10 +835,8 @@ private class ItemAdapter(
         return ItemViewHolder(view, onRemove)
     }
 
-    override fun getItemCount(): Int = items.size
-
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
-        holder.bind(items[position])
+        holder.bind(getItem(position))
     }
 
     class ItemViewHolder(
@@ -854,18 +851,69 @@ private class ItemAdapter(
             removeButton.setOnClickListener { onRemove(item) }
         }
     }
+
+    companion object {
+        private val ITEM_DIFF = object : DiffUtil.ItemCallback<ShuffleItem>() {
+            override fun areItemsTheSame(oldItem: ShuffleItem, newItem: ShuffleItem): Boolean {
+                return oldItem.type == newItem.type && oldItem.uri == newItem.uri
+            }
+
+            override fun areContentsTheSame(oldItem: ShuffleItem, newItem: ShuffleItem): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
 }
 
 private class QueueAdapter : RecyclerView.Adapter<QueueAdapter.QueueViewHolder>() {
     private val items = mutableListOf<String>()
+    private var previousQueueSnapshot: List<ShuffleItem> = emptyList()
+    private var currentItemIndex = RecyclerView.NO_POSITION
 
     fun submit(queue: List<ShuffleItem>, currentIndex: Int) {
-        items.clear()
-        queue.forEachIndexed { index, item ->
-            val marker = if (index == currentIndex) "▶" else "•"
-            items.add("$marker ${index + 1}. ${item.title}")
+        val normalizedIndex = if (currentIndex in queue.indices) currentIndex else RecyclerView.NO_POSITION
+        if (sameQueue(previousQueueSnapshot, queue)) {
+            if (currentItemIndex != normalizedIndex) {
+                if (currentItemIndex != RecyclerView.NO_POSITION) {
+                    items[currentItemIndex] = rowText(previousQueueSnapshot[currentItemIndex], currentItemIndex, false)
+                    notifyItemChanged(currentItemIndex)
+                }
+                if (normalizedIndex != RecyclerView.NO_POSITION) {
+                    items[normalizedIndex] = rowText(queue[normalizedIndex], normalizedIndex, true)
+                    notifyItemChanged(normalizedIndex)
+                }
+                currentItemIndex = normalizedIndex
+            }
+            previousQueueSnapshot = queue.toList()
+            return
         }
-        notifyDataSetChanged()
+
+        val previousItems = items.toList()
+        val nextItems = queue.mapIndexed { index, item ->
+            rowText(item, index, index == normalizedIndex)
+        }
+        val diff = object : DiffUtil.Callback() {
+            override fun getOldListSize(): Int = previousItems.size
+
+            override fun getNewListSize(): Int = nextItems.size
+
+            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                val oldItem = previousQueueSnapshot.getOrNull(oldItemPosition) ?: return false
+                val newItem = queue[newItemPosition]
+                return oldItem.type == newItem.type && oldItem.uri == newItem.uri
+            }
+
+            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                return previousItems[oldItemPosition] == nextItems[newItemPosition]
+            }
+        }
+
+        val diffResult = DiffUtil.calculateDiff(diff)
+        items.clear()
+        items.addAll(nextItems)
+        previousQueueSnapshot = queue.toList()
+        currentItemIndex = normalizedIndex
+        diffResult.dispatchUpdatesTo(this)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QueueViewHolder {
@@ -881,5 +929,19 @@ private class QueueAdapter : RecyclerView.Adapter<QueueAdapter.QueueViewHolder>(
 
     class QueueViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val title: TextView = itemView.findViewById(R.id.queueTitle)
+    }
+
+    private fun sameQueue(oldQueue: List<ShuffleItem>, newQueue: List<ShuffleItem>): Boolean {
+        if (oldQueue.size != newQueue.size) return false
+        return oldQueue.indices.all { index ->
+            oldQueue[index].type == newQueue[index].type &&
+                oldQueue[index].uri == newQueue[index].uri &&
+                oldQueue[index].title == newQueue[index].title
+        }
+    }
+
+    private fun rowText(item: ShuffleItem, index: Int, isCurrent: Boolean): String {
+        val marker = if (isCurrent) "▶" else "•"
+        return "$marker ${index + 1}. ${item.title}"
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce expensive `notifyDataSetChanged()` calls and improve RecyclerView update performance by leveraging `DiffUtil` and `ListAdapter`.
- Keep UI updates localized when only the current queue position changes to minimize redraws and improve responsiveness.

### Description
- Converted `ItemAdapter` to extend `ListAdapter<ShuffleItem, ItemViewHolder>` and added a `DiffUtil.ItemCallback` called `ITEM_DIFF`; replaced manual list handling with `submitList` and removed direct `notifyDataSetChanged()` usage.
- Reworked `QueueAdapter` to maintain a `previousQueueSnapshot` and `currentItemIndex` and to apply minimal updates when the current index changes, using `notifyItemChanged` for single-item updates.
- Implemented a `DiffUtil.Callback` path in `QueueAdapter` to compute diffs between previous and next queue states and call `DiffUtil.calculateDiff(...).dispatchUpdatesTo(this)` for full-list changes.
- Added helper functions `sameQueue` and `rowText`, and updated imports to include `DiffUtil` and `ListAdapter`.
- Removed two `NotifyDataSetChanged` entries from `app/lint-baseline.xml` that corresponded to the now-fixed usages.

### Testing
- Ran a full project build with `./gradlew assembleDebug`, which completed successfully.
- Ran Android lint with `./gradlew lint`, which completed successfully and removed the two baseline `NotifyDataSetChanged` findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc6bcb42808321ab3960cc9fb40255)