### PR TITLE
Add temporary Undo Snackbar for removed items

### DIFF
--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -14,13 +14,12 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.snackbar.BaseTransientBottomBar
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -46,6 +45,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var playbackStatus: TextView
     private lateinit var itemUriInput: EditText
     private lateinit var storageJsonInput: EditText
+    private lateinit var undoBannerContainer: LinearLayout
 
     private lateinit var loginButton: Button
     private lateinit var logoutButton: Button
@@ -60,8 +60,8 @@ class MainActivity : AppCompatActivity() {
 
     private val itemAdapter = ItemAdapter(onRemove = ::removeItem)
     private val queueAdapter = QueueAdapter()
-    private var pendingRemoval: PendingRemoval? = null
-    private var removalSnackbar: Snackbar? = null
+    private val pendingRemovals = mutableMapOf<Long, PendingRemoval>()
+    private var nextPendingRemovalId: Long = 0
 
     private var session = SessionState()
 
@@ -109,6 +109,7 @@ class MainActivity : AppCompatActivity() {
         playbackStatus = findViewById(R.id.playbackStatus)
         itemUriInput = findViewById(R.id.itemUriInput)
         storageJsonInput = findViewById(R.id.storageJsonInput)
+        undoBannerContainer = findViewById(R.id.undoBannerContainer)
 
         loginButton = findViewById(R.id.loginButton)
         logoutButton = findViewById(R.id.logoutButton)
@@ -413,31 +414,40 @@ class MainActivity : AppCompatActivity() {
         next.removeAt(removedIndex)
         saveItems(next)
         renderItemList()
-        pendingRemoval = PendingRemoval(item = item, index = removedIndex)
-
-        removalSnackbar?.dismiss()
-        removalSnackbar = Snackbar.make(findViewById(android.R.id.content), "Removed ${item.title}.", Snackbar.LENGTH_LONG)
-            .setAction("Undo") { undoPendingRemoval() }
-            .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
-                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                    if (event != DISMISS_EVENT_ACTION) {
-                        pendingRemoval = null
-                    }
-                    if (removalSnackbar === transientBottomBar) {
-                        removalSnackbar = null
-                    }
-                }
-            })
-        removalSnackbar?.show()
+        showUndoBanner(item, removedIndex)
     }
 
-    private fun undoPendingRemoval() {
-        val removal = pendingRemoval ?: return
+    private fun showUndoBanner(item: ShuffleItem, removedIndex: Int) {
+        val bannerView = layoutInflater.inflate(R.layout.undo_banner_row, undoBannerContainer, false)
+        val messageView = bannerView.findViewById<TextView>(R.id.undoMessage)
+        val undoButton = bannerView.findViewById<Button>(R.id.undoButton)
+        val removalId = nextPendingRemovalId++
+        messageView.text = "Removed ${item.title}."
+
+        val dismissRunnable = Runnable {
+            clearPendingRemoval(removalId)
+        }
+        val removal = PendingRemoval(
+            id = removalId,
+            item = item,
+            index = removedIndex,
+            bannerView = bannerView,
+            dismissRunnable = dismissRunnable,
+        )
+        pendingRemovals[removalId] = removal
+        undoBannerContainer.addView(bannerView, 0)
+        undoButton.setOnClickListener { undoPendingRemoval(removalId) }
+        monitorHandler.postDelayed(dismissRunnable, UNDO_BANNER_DURATION_MS)
+    }
+
+    private fun undoPendingRemoval(removalId: Long) {
+        val removal = pendingRemovals.remove(removalId) ?: return
+        monitorHandler.removeCallbacks(removal.dismissRunnable)
+        undoBannerContainer.removeView(removal.bannerView)
         val currentItems = getItems().toMutableList()
         if (currentItems.any { it.uri == removal.item.uri }) {
             renderItemList()
             toast("${removal.item.title} is already in your list.")
-            pendingRemoval = null
             return
         }
 
@@ -446,7 +456,11 @@ class MainActivity : AppCompatActivity() {
         saveItems(currentItems)
         renderItemList()
         toast("Restored ${removal.item.title}.")
-        pendingRemoval = null
+    }
+
+    private fun clearPendingRemoval(removalId: Long) {
+        val removal = pendingRemovals.remove(removalId) ?: return
+        undoBannerContainer.removeView(removal.bannerView)
     }
 
     private fun renderItemList() {
@@ -861,6 +875,7 @@ class MainActivity : AppCompatActivity() {
         private const val KEY_TOKEN_SCOPE = "spotifyShuffler.tokenScope"
         private const val KEY_ITEMS = "spotifyShuffler.items"
         private const val KEY_RUNTIME = "spotifyShuffler.runtime"
+        private const val UNDO_BANNER_DURATION_MS = 5_000L
     }
 }
 
@@ -890,8 +905,11 @@ data class ShuffleItem(
 )
 
 data class PendingRemoval(
+    val id: Long,
     val item: ShuffleItem,
     val index: Int,
+    val bannerView: View,
+    val dismissRunnable: Runnable,
 )
 
 enum class ActivationState(val value: String) {

--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -19,6 +19,8 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -58,6 +60,8 @@ class MainActivity : AppCompatActivity() {
 
     private val itemAdapter = ItemAdapter(onRemove = ::removeItem)
     private val queueAdapter = QueueAdapter()
+    private var pendingRemoval: PendingRemoval? = null
+    private var removalSnackbar: Snackbar? = null
 
     private var session = SessionState()
 
@@ -402,10 +406,47 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun removeItem(item: ShuffleItem) {
-        val next = getItems().toMutableList().apply { removeAll { it.uri == item.uri } }
+        val next = getItems().toMutableList()
+        val removedIndex = next.indexOfFirst { it.uri == item.uri }
+        if (removedIndex == -1) return
+
+        next.removeAt(removedIndex)
         saveItems(next)
         renderItemList()
-        toast("Removed ${item.title}.")
+        pendingRemoval = PendingRemoval(item = item, index = removedIndex)
+
+        removalSnackbar?.dismiss()
+        removalSnackbar = Snackbar.make(findViewById(android.R.id.content), "Removed ${item.title}.", Snackbar.LENGTH_LONG)
+            .setAction("Undo") { undoPendingRemoval() }
+            .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    if (event != DISMISS_EVENT_ACTION) {
+                        pendingRemoval = null
+                    }
+                    if (removalSnackbar === transientBottomBar) {
+                        removalSnackbar = null
+                    }
+                }
+            })
+        removalSnackbar?.show()
+    }
+
+    private fun undoPendingRemoval() {
+        val removal = pendingRemoval ?: return
+        val currentItems = getItems().toMutableList()
+        if (currentItems.any { it.uri == removal.item.uri }) {
+            renderItemList()
+            toast("${removal.item.title} is already in your list.")
+            pendingRemoval = null
+            return
+        }
+
+        val insertIndex = removal.index.coerceIn(0, currentItems.size)
+        currentItems.add(insertIndex, removal.item)
+        saveItems(currentItems)
+        renderItemList()
+        toast("Restored ${removal.item.title}.")
+        pendingRemoval = null
     }
 
     private fun renderItemList() {
@@ -846,6 +887,11 @@ data class ShuffleItem(
     val type: String,
     val uri: String,
     val title: String,
+)
+
+data class PendingRemoval(
+    val item: ShuffleItem,
+    val index: Int,
 )
 
 enum class ActivationState(val value: String) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -131,6 +131,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="220dp"
                     android:layout_marginTop="8dp" />
+
+                <LinearLayout
+                    android:id="@+id/undoBannerContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:orientation="vertical" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/undo_banner_row.xml
+++ b/app/src/main/res/layout/undo_banner_row.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    app:cardUseCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/undoMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:id="@+id/undoButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Undo" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
### Motivation
- Provide transient undo affordance after removing an item so users can restore accidental removals. 
- Preserve the original ordering of the configured list when restoring an item and handle cases where the item was re-added before Undo.

### Description
- Replace the immediate `toast`-only removal feedback in `removeItem` with a Material `Snackbar` that includes an `Undo` action and lifecycle callbacks. 
- Track the removed item and its original position with a `PendingRemoval` model and the `pendingRemoval` field.
- Implement `undoPendingRemoval()` to re-insert the removed `ShuffleItem` at its prior index (using `coerceIn` to clamp the index), persist via `saveItems`, and refresh the RecyclerView via `renderItemList`.
- Handle already re-added items by detecting duplicate URIs in `undoPendingRemoval()` and avoiding a second insert while keeping the UI synchronized.

### Testing
- Ran `./gradlew check` and the build checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d19c12fec48321a4b7ea17a6e3f9cf)