### PR TITLE
Remove non-default app styling

### DIFF
--- a/app/src/main/res/drawable/default_border.xml
+++ b/app/src/main/res/drawable/default_border.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="#808080" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,7 +7,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="8dp">
 
         <TextView
             android:layout_width="match_parent"
@@ -19,190 +20,226 @@
             android:layout_height="wrap_content"
             android:text="Randomly cycles through your saved set of Spotify albums/playlists while keeping each item's tracks in order." />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="1) Connect Spotify" />
-
         <LinearLayout
-            style="?android:attr/buttonBarStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginTop="8dp"
+            android:background="@drawable/default_border"
+            android:orientation="vertical"
+            android:padding="8dp">
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/loginButton"
-                android:layout_width="0dp"
+            <TextView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Connect" />
+                android:text="1) Connect Spotify" />
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/logoutButton"
-                android:layout_width="0dp"
+            <LinearLayout
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Disconnect" />
+                android:orientation="horizontal">
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/loginButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Connect" />
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/logoutButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Disconnect" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/authStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Not connected." />
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/authStatus"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Not connected." />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="2) Manage Album/Playlist List" />
-
-        <EditText
-            android:id="@+id/itemUriInput"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="spotify:album:... or spotify:playlist:..."
-            android:importantForAutofill="no"
-            android:imeOptions="actionDone"
-            android:inputType="textUri" />
-
         <LinearLayout
-            style="?android:attr/buttonBarStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginTop="8dp"
+            android:background="@drawable/default_border"
+            android:orientation="vertical"
+            android:padding="8dp">
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/addButton"
-                android:layout_width="0dp"
+            <TextView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Add" />
+                android:text="2) Manage Album/Playlist List" />
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/importPlaylistButton"
-                android:layout_width="0dp"
+            <EditText
+                android:id="@+id/itemUriInput"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Import Albums" />
+                android:hint="spotify:album:... or spotify:playlist:..."
+                android:importantForAutofill="no"
+                android:imeOptions="actionDone"
+                android:inputType="textUri" />
+
+            <LinearLayout
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/addButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Add" />
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/importPlaylistButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Import Albums" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Tip: You can paste a normal Spotify URL and it will be converted. For playlist imports, you can also paste a playlist ID." />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/itemRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="220dp" />
+
+            <LinearLayout
+                android:id="@+id/undoBannerContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
         </LinearLayout>
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Tip: You can paste a normal Spotify URL and it will be converted. For playlist imports, you can also paste a playlist ID." />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/itemRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="220dp" />
-
         <LinearLayout
-            android:id="@+id/undoBannerContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" />
+            android:layout_marginTop="8dp"
+            android:background="@drawable/default_border"
+            android:orientation="vertical"
+            android:padding="8dp">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="3) Start Shuffle Session" />
-
-        <LinearLayout
-            style="?android:attr/buttonBarStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/startButton"
-                android:layout_width="wrap_content"
+            <TextView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Start" />
+                android:text="3) Start Shuffle Session" />
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/reattachButton"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Reattach"
-                android:visibility="gone" />
+                android:orientation="horizontal">
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/skipButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Skip" />
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/startButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Start" />
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/stopButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Stop" />
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/reattachButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Reattach"
+                    android:visibility="gone" />
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/skipButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Skip" />
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/stopButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Stop" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/playbackStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/queueRecycler"
+                android:layout_width="match_parent"
+                android:layout_height="220dp" />
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/playbackStatus"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/queueRecycler"
-            android:layout_width="match_parent"
-            android:layout_height="220dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="4) Import / Export Data" />
-
         <LinearLayout
-            style="?android:attr/buttonBarStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginTop="8dp"
+            android:background="@drawable/default_border"
+            android:orientation="vertical"
+            android:padding="8dp">
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/exportStorageButton"
-                android:layout_width="0dp"
+            <TextView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Export Data JSON" />
+                android:text="4) Import / Export Data" />
 
-            <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:id="@+id/importStorageButton"
-                android:layout_width="0dp"
+            <LinearLayout
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Import Data JSON" />
+                android:orientation="horizontal">
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/exportStorageButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Export Data JSON" />
+
+                <Button
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:id="@+id/importStorageButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Import Data JSON" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Data JSON" />
+
+            <EditText
+                android:id="@+id/storageJsonInput"
+                android:layout_width="match_parent"
+                android:layout_height="180dp"
+                android:gravity="top|start"
+                android:hint="{&quot;shuffle-by-album.items&quot;:[{&quot;type&quot;:&quot;album&quot;,&quot;uri&quot;:..."
+                android:importantForAutofill="no"
+                android:inputType="textMultiLine"
+                android:scrollbars="vertical" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box." />
         </LinearLayout>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Data JSON" />
-
-        <EditText
-            android:id="@+id/storageJsonInput"
-            android:layout_width="match_parent"
-            android:layout_height="180dp"
-            android:gravity="top|start"
-            android:hint="{&quot;shuffle-by-album.items&quot;:[{&quot;type&quot;:&quot;album&quot;,&quot;uri&quot;:..."
-            android:importantForAutofill="no"
-            android:inputType="textMultiLine"
-            android:scrollbars="vertical" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box." />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true">
@@ -8,283 +7,202 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:orientation="vertical">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Shuffle By Album"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+            android:text="Shuffle By Album" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
             android:text="Randomly cycles through your saved set of Spotify albums/playlists while keeping each item's tracks in order." />
 
-        <com.google.android.material.card.MaterialCardView
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            app:cardUseCompatPadding="true">
+            android:text="1) Connect Spotify" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="12dp">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="1) Connect Spotify"
-                    android:textStyle="bold" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="horizontal">
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button"
-                        android:id="@+id/loginButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Connect" />
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/logoutButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:layout_weight="1"
-                        android:text="Disconnect" />
-                </LinearLayout>
-
-                <TextView
-                    android:id="@+id/authStatus"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Not connected." />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.card.MaterialCardView
+        <LinearLayout
+            style="?android:attr/buttonBarStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:cardUseCompatPadding="true">
+            android:orientation="horizontal">
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/loginButton"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="12dp">
+                android:layout_weight="1"
+                android:text="Connect" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="2) Manage Album/Playlist List"
-                    android:textStyle="bold" />
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/logoutButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Disconnect" />
+        </LinearLayout>
 
-                <EditText
-                    android:id="@+id/itemUriInput"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:hint="spotify:album:... or spotify:playlist:..."
-                    android:importantForAutofill="no"
-                    android:imeOptions="actionDone"
-                    android:inputType="textUri" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="horizontal">
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button"
-                        android:id="@+id/addButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Add" />
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/importPlaylistButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:layout_weight="1"
-                        android:text="Import Albums" />
-                </LinearLayout>
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Tip: You can paste a normal Spotify URL and it will be converted. For playlist imports, you can also paste a playlist ID." />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/itemRecycler"
-                    android:layout_width="match_parent"
-                    android:layout_height="220dp"
-                    android:layout_marginTop="8dp" />
-
-                <LinearLayout
-                    android:id="@+id/undoBannerContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="vertical" />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.card.MaterialCardView
+        <TextView
+            android:id="@+id/authStatus"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:cardUseCompatPadding="true">
+            android:text="Not connected." />
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="12dp">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="3) Start Shuffle Session"
-                    android:textStyle="bold" />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="horizontal">
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button"
-                        android:id="@+id/startButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Start" />
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/reattachButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:text="Reattach"
-                        android:visibility="gone" />
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/skipButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:text="Skip" />
-
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/stopButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:text="Stop" />
-                </LinearLayout>
-
-                <TextView
-                    android:id="@+id/playbackStatus"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/queueRecycler"
-                    android:layout_width="match_parent"
-                    android:layout_height="220dp"
-                    android:layout_marginTop="8dp" />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.card.MaterialCardView
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:cardUseCompatPadding="true">
+            android:text="2) Manage Album/Playlist List" />
 
-            <LinearLayout
-                android:layout_width="match_parent"
+        <EditText
+            android:id="@+id/itemUriInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="spotify:album:... or spotify:playlist:..."
+            android:importantForAutofill="no"
+            android:imeOptions="actionDone"
+            android:inputType="textUri" />
+
+        <LinearLayout
+            style="?android:attr/buttonBarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/addButton"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="12dp">
+                android:layout_weight="1"
+                android:text="Add" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="4) Import / Export Data"
-                    android:textStyle="bold" />
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/importPlaylistButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Import Albums" />
+        </LinearLayout>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:orientation="horizontal">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Tip: You can paste a normal Spotify URL and it will be converted. For playlist imports, you can also paste a playlist ID." />
 
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button"
-                        android:id="@+id/exportStorageButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Export Data JSON" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/itemRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="220dp" />
 
-                    <com.google.android.material.button.MaterialButton
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                        android:id="@+id/importStorageButton"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
-                        android:layout_weight="1"
-                        android:text="Import Data JSON" />
-                </LinearLayout>
+        <LinearLayout
+            android:id="@+id/undoBannerContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Data JSON"
-                    android:textStyle="bold" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="3) Start Shuffle Session" />
 
-                <EditText
-                    android:id="@+id/storageJsonInput"
-                    android:layout_width="match_parent"
-                    android:layout_height="180dp"
-                    android:layout_marginTop="8dp"
-                    android:gravity="top|start"
-                    android:hint="{&quot;shuffle-by-album.items&quot;:[{&quot;type&quot;:&quot;album&quot;,&quot;uri&quot;:..."
-                    android:inputType="textMultiLine"
-                    android:scrollbars="vertical"
-                    android:importantForAutofill="no" />
+        <LinearLayout
+            style="?android:attr/buttonBarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box."
-                    android:textSize="12sp" />
-            </LinearLayout>
-        </com.google.android.material.card.MaterialCardView>
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/startButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Start" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/reattachButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Reattach"
+                android:visibility="gone" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/skipButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Skip" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/stopButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Stop" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/playbackStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/queueRecycler"
+            android:layout_width="match_parent"
+            android:layout_height="220dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="4) Import / Export Data" />
+
+        <LinearLayout
+            style="?android:attr/buttonBarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/exportStorageButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Export Data JSON" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:id="@+id/importStorageButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Import Data JSON" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Data JSON" />
+
+        <EditText
+            android:id="@+id/storageJsonInput"
+            android:layout_width="match_parent"
+            android:layout_height="180dp"
+            android:gravity="top|start"
+            android:hint="{&quot;shuffle-by-album.items&quot;:[{&quot;type&quot;:&quot;album&quot;,&quot;uri&quot;:..."
+            android:importantForAutofill="no"
+            android:inputType="textMultiLine"
+            android:scrollbars="vertical" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box." />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/item_row.xml
+++ b/app/src/main/res/layout/item_row.xml
@@ -3,7 +3,9 @@
     style="?android:attr/buttonBarStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:background="@drawable/default_border"
+    android:orientation="horizontal"
+    android:padding="4dp">
 
     <TextView
         android:id="@+id/title"

--- a/app/src/main/res/layout/item_row.xml
+++ b/app/src/main/res/layout/item_row.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="?android:attr/buttonBarStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
-    android:padding="8dp">
+    android:orientation="horizontal">
 
     <TextView
         android:id="@+id/title"
@@ -13,8 +12,8 @@
         android:layout_weight="1" />
 
     <Button
+        style="?android:attr/buttonBarButtonStyle"
         android:id="@+id/removeButton"
-        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Remove" />

--- a/app/src/main/res/layout/undo_banner_row.xml
+++ b/app/src/main/res/layout/undo_banner_row.xml
@@ -3,7 +3,9 @@
     style="?android:attr/buttonBarStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:background="@drawable/default_border"
+    android:orientation="horizontal"
+    android:padding="4dp">
 
     <TextView
         android:id="@+id/undoMessage"

--- a/app/src/main/res/layout/undo_banner_row.xml
+++ b/app/src/main/res/layout/undo_banner_row.xml
@@ -1,30 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="?android:attr/buttonBarStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="8dp"
-    app:cardUseCompatPadding="true">
+    android:orientation="horizontal">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/undoMessage"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:padding="12dp">
+        android:layout_weight="1" />
 
-        <TextView
-            android:id="@+id/undoMessage"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
-
-        <com.google.android.material.button.MaterialButton
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:id="@+id/undoButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Undo" />
-    </LinearLayout>
-</com.google.android.material.card.MaterialCardView>
+    <Button
+        style="?android:attr/buttonBarButtonStyle"
+        android:id="@+id/undoButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Undo" />
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="purple_500">#6750A4</color>
-    <color name="purple_700">#4F378B</color>
-    <color name="teal_200">#03DAC5</color>
-</resources>
+<resources />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.ShuffleByAlbum" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-    </style>
+    <style name="Theme.ShuffleByAlbum" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
### Motivation
- Revert custom visual styling across the app so UI uses platform/default widget presentation and removes bespoke Material wrappers and custom colors.

### Description
- Replace Material card wrappers, Material button widgets, and explicit text appearances in `app/src/main/res/layout/activity_main.xml` with plain `LinearLayout`, `TextView`, `Button`, `EditText`, and `RecyclerView`, and use platform button-bar attributes where appropriate.
- Simplify list row and undo banner layouts in `app/src/main/res/layout/item_row.xml` and `app/src/main/res/layout/undo_banner_row.xml` to default views and apply `?android:attr/buttonBarStyle`/`?android:attr/buttonBarButtonStyle` for button consistency.
- Clear custom color resources in `app/src/main/res/values/colors.xml` and reset `Theme.ShuffleByAlbum` in `app/src/main/res/values/themes.xml` to inherit `Theme.MaterialComponents.DayNight.NoActionBar` with no overrides.

### Testing
- Ran `./gradlew check` and the build completed successfully, with lint and resource processing passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6814ed2f08321a2465e451f182715)