### PR TITLE
Use launcher app name for in-app title

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Shuffle By Album"
+            android:text="@string/app_name"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
 
         <TextView


### PR DESCRIPTION
### Motivation
- Align the in-app header with the app launcher title and support variant-specific labels by removing a hardcoded string.

### Description
- Replaced the hardcoded header `android:text="Shuffle By Album"` with `android:text="@string/app_name"` in `app/src/main/res/layout/activity_main.xml`.

### Testing
- Ran `./gradlew check` and the build and lint tasks completed successfully (`BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6a0da857c8321848b72c45375f7dd)