### PR TITLE
Remove custom app color overrides

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="purple_500">#6750A4</color>
-    <color name="purple_700">#4F378B</color>
-    <color name="teal_200">#03DAC5</color>
-</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.ShuffleByAlbum" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-    </style>
+    <style name="Theme.ShuffleByAlbum" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
### Motivation
- Use the default MaterialComponents color system by removing app-specific primary/secondary/status bar color overrides so the app no longer forces a custom palette.

### Description
- Deleted the custom palette file `app/src/main/res/values/colors.xml` and removed explicit color items from `app/src/main/res/values/themes.xml`, leaving `Theme.ShuffleByAlbum` to inherit from `Theme.MaterialComponents.DayNight.NoActionBar`.

### Testing
- Ran `./gradlew check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6ac6d6de08321afd28181eeb8f5b2)