### PR TITLE
Extract layout spacing and sizes into dimens.xml and update layouts

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="@dimen/main_screen_content_padding">
 
         <TextView
             android:layout_width="match_parent"
@@ -20,20 +20,20 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/control_vertical_spacing"
             android:text="Randomly cycles through your saved set of Spotify albums/playlists while keeping each item's tracks in order." />
 
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="@dimen/section_spacing_after_intro"
             app:cardUseCompatPadding="true">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="12dp">
+                android:padding="@dimen/card_content_padding">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -44,7 +44,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
@@ -60,7 +60,7 @@
                         android:id="@+id/disconnectButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:layout_weight="1"
                         android:text="Disconnect" />
                 </LinearLayout>
@@ -69,7 +69,7 @@
                     android:id="@+id/authStatus"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:text="Not connected." />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
@@ -77,14 +77,14 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/control_vertical_spacing"
             app:cardUseCompatPadding="true">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="12dp">
+                android:padding="@dimen/card_content_padding">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -96,7 +96,7 @@
                     android:id="@+id/itemUriInput"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:hint="spotify:album:... or spotify:playlist:..."
                     android:importantForAutofill="no"
                     android:imeOptions="actionDone"
@@ -105,7 +105,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
@@ -121,7 +121,7 @@
                         android:id="@+id/importPlaylistButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:layout_weight="1"
                         android:text="Import Albums" />
                 </LinearLayout>
@@ -129,20 +129,20 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:text="Tip: You can paste a normal Spotify URL and it will be converted. For playlist imports, you can also paste a playlist ID." />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/itemRecycler"
                     android:layout_width="match_parent"
-                    android:layout_height="220dp"
-                    android:layout_marginTop="8dp" />
+                    android:layout_height="@dimen/item_list_height"
+                    android:layout_marginTop="@dimen/control_vertical_spacing" />
 
                 <LinearLayout
                     android:id="@+id/undoBannerContainer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:orientation="vertical" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
@@ -150,14 +150,14 @@
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/control_vertical_spacing"
             app:cardUseCompatPadding="true">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="12dp">
+                android:padding="@dimen/card_content_padding">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -168,7 +168,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
@@ -183,7 +183,7 @@
                         android:id="@+id/reattachButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:text="Reattach"
                         android:visibility="gone" />
 
@@ -192,7 +192,7 @@
                         android:id="@+id/skipButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:text="Skip" />
 
                     <com.google.android.material.button.MaterialButton
@@ -200,7 +200,7 @@
                         android:id="@+id/stopButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:text="Stop" />
                 </LinearLayout>
 
@@ -208,27 +208,27 @@
                     android:id="@+id/playbackStatus"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp" />
+                    android:layout_marginTop="@dimen/control_vertical_spacing" />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/queueRecycler"
                     android:layout_width="match_parent"
-                    android:layout_height="220dp"
-                    android:layout_marginTop="8dp" />
+                    android:layout_height="@dimen/item_list_height"
+                    android:layout_marginTop="@dimen/control_vertical_spacing" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/control_vertical_spacing"
             app:cardUseCompatPadding="true">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="12dp">
+                android:padding="@dimen/card_content_padding">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -239,7 +239,7 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:orientation="horizontal">
 
                     <com.google.android.material.button.MaterialButton
@@ -255,7 +255,7 @@
                         android:id="@+id/importStorageButton"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:layout_weight="1"
                         android:text="Import Data JSON" />
                 </LinearLayout>
@@ -263,15 +263,15 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:text="Data JSON"
                     android:textStyle="bold" />
 
                 <EditText
                     android:id="@+id/storageJsonInput"
                     android:layout_width="match_parent"
-                    android:layout_height="180dp"
-                    android:layout_marginTop="8dp"
+                    android:layout_height="@dimen/storage_json_editor_height"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:gravity="top|start"
                     android:hint="{&quot;shuffle-by-album.items&quot;:[{&quot;type&quot;:&quot;album&quot;,&quot;uri&quot;:..."
                     android:inputType="textMultiLine"
@@ -281,7 +281,7 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="@dimen/control_vertical_spacing"
                     android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box."
                     android:textSize="12sp" />
             </LinearLayout>

--- a/app/src/main/res/layout/item_row.xml
+++ b/app/src/main/res/layout/item_row.xml
@@ -4,7 +4,7 @@
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:padding="8dp">
+    android:padding="@dimen/item_row_padding">
 
     <TextView
         android:id="@+id/title"

--- a/app/src/main/res/layout/queue_row.xml
+++ b/app/src/main/res/layout/queue_row.xml
@@ -3,4 +3,4 @@
     android:id="@+id/queueTitle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp" />
+    android:padding="@dimen/queue_row_padding" />

--- a/app/src/main/res/layout/undo_banner_row.xml
+++ b/app/src/main/res/layout/undo_banner_row.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="8dp"
+    android:layout_marginBottom="@dimen/undo_banner_bottom_spacing"
     app:cardUseCompatPadding="true">
 
     <LinearLayout
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:padding="12dp">
+        android:padding="@dimen/undo_banner_content_padding">
 
         <TextView
             android:id="@+id/undoMessage"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="main_screen_content_padding">16dp</dimen>
+    <dimen name="section_spacing_after_intro">12dp</dimen>
+    <dimen name="card_content_padding">12dp</dimen>
+    <dimen name="control_vertical_spacing">8dp</dimen>
+    <dimen name="button_group_horizontal_spacing">8dp</dimen>
+    <dimen name="item_list_height">220dp</dimen>
+    <dimen name="storage_json_editor_height">180dp</dimen>
+    <dimen name="queue_row_padding">8dp</dimen>
+    <dimen name="item_row_padding">8dp</dimen>
+    <dimen name="undo_banner_bottom_spacing">8dp</dimen>
+    <dimen name="undo_banner_content_padding">12dp</dimen>
+</resources>


### PR DESCRIPTION
### Motivation
- Replace hard-coded padding, margin and fixed heights in XML layouts with centralized dimension resources for consistent spacing and easier theming.
- Prepare layout values for future adjustments and localization/scaling without editing multiple layout files.

### Description
- Added `res/values/dimens.xml` with named dimension resources like `main_screen_content_padding`, `control_vertical_spacing`, `item_list_height`, and others.
- Updated `activity_main.xml` to replace inline `dp` values for paddings, margins and heights with the new dimension resources and adjusted recycler/edit text heights to use `@dimen` values.
- Updated `item_row.xml`, `queue_row.xml`, and `undo_banner_row.xml` to use the corresponding dimension resources for padding and spacing.

### Testing
- Ran `./gradlew assembleDebug` which completed successfully.
- Ran `./gradlew lint` which reported no new layout/lint issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6c9858898832182eca5b2b7beaf4c)