### PR TITLE
Use filled style for Undo banner button

### DIFF
--- a/app/src/main/res/layout/undo_banner_row.xml
+++ b/app/src/main/res/layout/undo_banner_row.xml
@@ -21,7 +21,7 @@
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
         <com.google.android.material.button.MaterialButton
-            style="@style/Widget.MaterialComponents.Button.TextButton"
+            style="@style/Widget.MaterialComponents.Button"
             android:id="@+id/undoButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### Motivation
- Make the Undo action visually consistent and more prominent by switching it from a text-style button to a filled CTA treatment.

### Description
- Updated the `undoButton` in `app/src/main/res/layout/undo_banner_row.xml` to use `@style/Widget.MaterialComponents.Button` instead of `@style/Widget.MaterialComponents.Button.TextButton`.

### Testing
- Ran `./gradlew check` which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6e78164d88321b22c80e7aa4281fd)