### PR TITLE
Use shared item row padding for queue rows

### DIFF
--- a/app/src/main/res/layout/queue_row.xml
+++ b/app/src/main/res/layout/queue_row.xml
@@ -3,4 +3,4 @@
     android:id="@+id/queueTitle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/queue_row_padding" />
+    android:padding="@dimen/item_row_padding" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,7 +7,6 @@
     <dimen name="button_group_horizontal_spacing">8dp</dimen>
     <dimen name="item_list_height">220dp</dimen>
     <dimen name="storage_json_editor_height">180dp</dimen>
-    <dimen name="queue_row_padding">8dp</dimen>
     <dimen name="item_row_padding">8dp</dimen>
     <dimen name="undo_banner_bottom_spacing">8dp</dimen>
     <dimen name="undo_banner_content_padding">12dp</dimen>


### PR DESCRIPTION
### Motivation
- Unify padding by removing the separate `queue_row_padding` and reusing the existing `item_row_padding` for queue row layouts to reduce duplicate resource definitions.

### Description
- Updated `app/src/main/res/layout/queue_row.xml` to use `@dimen/item_row_padding` instead of `@dimen/queue_row_padding`.
- Removed the now-unused `<dimen name="queue_row_padding">` from `app/src/main/res/values/dimens.xml`.

### Testing
- Ran `./gradlew check`, which failed in this environment due to dependency fetch errors (HTTP 403 from Google Maven / Maven Central), so the Gradle checks could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6fdfc65f48321917ff7799d3b1f03)