### PR TITLE
Remove specific implementation and test dependencies from app build file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,14 +81,8 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
-
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 }


### PR DESCRIPTION
### Motivation
- Remove explicit dependency declarations from `app/build.gradle.kts`, likely to centralize dependency/version management or avoid duplicate declarations.

### Description
- Deleted `implementation("androidx.core:core-ktx:1.13.1")`, `implementation("androidx.constraintlayout:constraintlayout:2.1.4")`, and the test dependencies `testImplementation("junit:junit:4.13.2")`, `androidTestImplementation("androidx.test.ext:junit:1.2.1")`, and `androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")` from `app/build.gradle.kts`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d70b5675b88321a081317e718d17d2)