### PR TITLE
Include added item title in confirmation toast

### DIFF
--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -273,7 +273,7 @@ class MainActivity : AppCompatActivity() {
         saveItems(items)
         renderItemList()
         itemUriInput.setText("")
-        toast("Item added.")
+        toast("Added ${quotedTitle(titled.title)}.")
     }
 
     private suspend fun importAlbumsFromPlaylist() {


### PR DESCRIPTION
### Motivation
- Make add-item confirmation more informative by showing the added item's title instead of a generic message.

### Description
- Replace `toast("Item added.")` with `toast("Added ${quotedTitle(titled.title)}.")` to reuse `quotedTitle(...)` formatting for consistent display.

### Testing
- Ran `./gradlew check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7e1e1b0008321adaa44dbd512b2b4)