### PR TITLE
Update import/export data UI copy

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/control_vertical_spacing"
-            android:text="Randomly cycles through your saved set of Spotify albums/playlists while keeping each item's tracks in order." />
+            android:text="Randomly cycles through a saved set of Spotify albums/playlists while keeping each item's tracks in order." />
 
         <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -249,7 +249,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="Export Data JSON" />
+                        android:text="Export Data" />
 
                     <com.google.android.material.button.MaterialButton
                         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
@@ -258,15 +258,15 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="@dimen/button_group_horizontal_spacing"
                         android:layout_weight="1"
-                        android:text="Import Data JSON" />
+                        android:text="Import Data" />
                 </LinearLayout>
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/control_vertical_spacing"
-                    android:text="Data JSON"
-                    android:textStyle="bold" />
+                    android:text="@string/storage_data_helper_text"
+                    android:textSize="@dimen/helper_text_size" />
 
                 <EditText
                     android:id="@+id/storageJsonInput"
@@ -279,12 +279,6 @@
                     android:scrollbars="vertical"
                     android:importantForAutofill="no" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/control_vertical_spacing"
-                    android:text="Export copies your saved items into the text box. Import replaces saved items with the data in the text box."
-                    android:textSize="@dimen/helper_text_size" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="app_name">Shuffle By Album</string>
     <string name="item_input_helper_text"><b>Add</b> adds one item to the list\n<b>Import Albums</b> processes a playlist and adds each song\'s album to the list</string>
+    <string name="storage_data_helper_text"><b>Export Data</b> copies your saved items into the text box\n<b>Import Data</b> replaces your saved items with the data in the text box</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Make the Import/Export controls less JSON-specific and match the formatting used for the Add / Import Albums controls.  
- Surface clearer helper copy that explains the effect of the Export and Import actions in two short lines with bold leading words.  

### Description
- Changed the export button text from `Export Data JSON` to `Export Data` in `app/src/main/res/layout/activity_main.xml`.  
- Changed the import button text from `Import Data JSON` to `Import Data` in `app/src/main/res/layout/activity_main.xml`.  
- Removed the `Data JSON` label above the multiline input and replaced it with a helper `TextView` that uses a new string resource.  
- Added `storage_data_helper_text` to `app/src/main/res/values/strings.xml` containing two lines: `Export Data copies your saved items into the text box` and `Import Data replaces your saved items with the data in the text box` (formatted with bold leading words to match nearby helper text).  

### Testing
- Ran `./gradlew check` and it failed in this environment due to missing Android SDK configuration (`ANDROID_HOME` or `local.properties` `sdk.dir`), so project-level checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1c2350b608321af5e6da14c9f58ad)