### PR TITLE
Handle Spotify OAuth access_denied callback

### DIFF
--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -357,7 +357,11 @@ class MainActivity : AppCompatActivity() {
         if (uri == null || uri.scheme != "shufflebyalbum") return false
         val error = uri.getQueryParameter("error")
         if (error != null) {
-            authStatus.text = "Spotify authorization error: $error"
+            authStatus.text = if (error == "access_denied") {
+                "Spotify authorization denied."
+            } else {
+                "Spotify authorization error: $error"
+            }
             prefs.edit().remove(KEY_VERIFIER).apply()
             return true
         }


### PR DESCRIPTION
### Motivation
- Map Spotify's `access_denied` OAuth error to a clearer user-facing status instead of the generic error message.

### Description
- Update `processAuthRedirect` in `app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt` to set `authStatus.text` to `"Spotify authorization denied."` when `error == "access_denied"`, preserving the original `"Spotify authorization error: $error"` for other errors.

### Testing
- Ran `./gradlew check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e68bf212748321b6b62a04ccbb045b)