### PR TITLE
Adjust recoverable playback monitor error messaging

### DIFF
--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -609,7 +609,7 @@ class MainActivity : AppCompatActivity() {
                     cooldownKey = "monitor-failure-detached",
                 )
             } else {
-                playbackStatus.text = "Unable to check playback state right now."
+                playbackStatus.text = "Playback monitor encountered an error: $failure"
                 reportError(
                     toastMessage = "Playback monitor encountered an error.",
                     cooldownKey = "monitor-failure-recoverable",
@@ -618,7 +618,8 @@ class MainActivity : AppCompatActivity() {
             return
         }
         val snapshot = snapshotResult.snapshot ?: run {
-            playbackStatus.text = "Unable to check playback state right now."
+            val failure = "missing playback snapshot."
+            playbackStatus.text = "Playback monitor encountered an error: $failure"
             reportError(
                 toastMessage = "Playback monitor encountered an error.",
                 cooldownKey = "monitor-failure-recoverable",

--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -618,7 +618,7 @@ class MainActivity : AppCompatActivity() {
             return
         }
         val snapshot = snapshotResult.snapshot ?: run {
-            val failure = "missing playback snapshot."
+            val failure = "Missing playback snapshot."
             playbackStatus.text = "Playback monitor encountered an error: $failure"
             reportError(
                 toastMessage = "Playback monitor encountered an error.",


### PR DESCRIPTION
### Motivation
- Make recoverable playback monitor failures surface a clear, consistent status line that includes the error detail in the format `Playback monitor encountered an error: <error>` so users can see what went wrong. 
- Keep the user-facing toast generic as `Playback monitor encountered an error.` while providing a concrete fallback when a playback snapshot is unexpectedly missing.

### Description
- Update `playbackStatus.text` in the recoverable monitor-failure branch to `Playback monitor encountered an error: $failure` in `MainActivity.kt`.
- Add a fallback `failure = "missing playback snapshot."` and set `playbackStatus.text` to include that message when the playback snapshot is null. 
- Preserve the recoverable error toast message as the exact string `Playback monitor encountered an error.` and keep the existing cooldown key `monitor-failure-recoverable`.

### Testing
- Ran `./gradlew check` and the build completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e6923f47c88321913bbeeaa03088d2)