### PR TITLE
Fix compilation failures in MainActivity and remove unused dimens

### DIFF
--- a/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
+++ b/app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,7 +8,5 @@
     <dimen name="item_list_height">220dp</dimen>
     <dimen name="storage_json_editor_height">180dp</dimen>
     <dimen name="item_row_padding">8dp</dimen>
-    <dimen name="undo_banner_bottom_spacing">8dp</dimen>
-    <dimen name="undo_banner_content_padding">12dp</dimen>
     <dimen name="helper_text_size">12sp</dimen>
 </resources>


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by a missing `LinearLayout` type and remove lint‑flagged unused dimension resources so the project passes validation.

### Description
- Added `import android.widget.LinearLayout` to `app/src/main/java/io/github/maxnanasy/shufflebyalbum/MainActivity.kt` and removed `undo_banner_bottom_spacing` and `undo_banner_content_padding` from `app/src/main/res/values/dimens.xml`.

### Testing
- Ran `./gradlew check` and the build and lint checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e97e6d5e4083218e8589d3d522ff28)