### PR TITLE
Add --cross-platform flag to scripts/ui-test-list

### DIFF
--- a/app/src/androidTest/java/io/github/maxnanasy/shufflebyalbum/ShareIntentUiTest.kt
+++ b/app/src/androidTest/java/io/github/maxnanasy/shufflebyalbum/ShareIntentUiTest.kt
@@ -14,9 +14,11 @@ import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 @DisplayName("Share Intent")
+@Tag("platform-specific")
 class ShareIntentUiTest : AbstractUiTestCase() {
     private lateinit var instrumentation: Instrumentation
     private lateinit var targetContext: Context

--- a/scripts/ui-test-list
+++ b/scripts/ui-test-list
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
+import argparse
 import fnmatch
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 SUITE_PATTERNS = [
@@ -335,7 +335,11 @@ def find_top_level_class(text: str) -> tuple[str, str, int, int] | None:
     return None
 
 
-def parse_suite_tests(path: str, text: str) -> list[tuple[str, str]]:
+def parse_suite_tests(
+    path: str,
+    text: str,
+    cross_platform: bool = False,
+) -> list[tuple[str, str]]:
     parsed_class = find_top_level_class(text)
     if parsed_class is None:
         return []
@@ -343,6 +347,9 @@ def parse_suite_tests(path: str, text: str) -> list[tuple[str, str]]:
     _class_name, suite_name, class_open, class_close = parsed_class
     suite_tests: list[tuple[str, str]] = []
     base_filename = Path(path).name
+    suite_title = f'{suite_name}:'
+    if not cross_platform:
+        suite_title = f'{suite_name} [{base_filename}]:'
 
     index = class_open + 1
     depth = 1
@@ -376,7 +383,7 @@ def parse_suite_tests(path: str, text: str) -> list[tuple[str, str]]:
             method_name = parse_method_name(declaration)
             if method_name is not None:
                 test_name = annotation_value(pending_annotations, 'DisplayName') or method_name
-                suite_tests.append((f'{suite_name} [{base_filename}]:', test_name))
+                suite_tests.append((suite_title, test_name))
 
         pending_annotations.clear()
         if terminator is None:
@@ -401,7 +408,7 @@ def render_test_list(suite_tests: list[tuple[str, str]]) -> str:
     return ''.join(f'{line}\n' for line in lines)
 
 
-def suite_test_list(ref: str | None) -> str:
+def suite_test_list(ref: str | None, cross_platform: bool = False) -> str:
     if ref is None:
         root = repo_root()
         suite_files = list_working_copy_files(root)
@@ -409,7 +416,7 @@ def suite_test_list(ref: str | None) -> str:
         for path in suite_files:
             text = working_copy_file_at(root, path)
             if text is not None:
-                suite_tests.extend(parse_suite_tests(path, text))
+                suite_tests.extend(parse_suite_tests(path, text, cross_platform))
         return render_test_list(suite_tests)
 
     suite_files = list_ref_files(ref)
@@ -417,17 +424,25 @@ def suite_test_list(ref: str | None) -> str:
     for path in suite_files:
         text = ref_file_at(ref, path)
         if text is not None:
-            suite_tests.extend(parse_suite_tests(path, text))
+            suite_tests.extend(parse_suite_tests(path, text, cross_platform))
     return render_test_list(suite_tests)
 
 
 def main() -> int:
-    if len(sys.argv) > 2:
-        print(f'Usage: {sys.argv[0]} [ref]', file=sys.stderr)
-        return 1
+    parser = argparse.ArgumentParser(description='List Android UI tests grouped by suite.')
+    parser.add_argument(
+        'ref',
+        nargs='?',
+        help='Git ref to list tests from instead of the working copy',
+    )
+    parser.add_argument(
+        '--cross-platform',
+        action='store_true',
+        help='Omit source filenames from suite headings for cross-platform output',
+    )
+    args = parser.parse_args()
 
-    ref = sys.argv[1] if len(sys.argv) == 2 else None
-    print(suite_test_list(ref), end='')
+    print(suite_test_list(args.ref, args.cross_platform), end='')
     return 0
 
 

--- a/scripts/ui-test-list
+++ b/scripts/ui-test-list
@@ -19,6 +19,8 @@ TEST_ANNOTATIONS = {
     'TestFactory',
     'TestTemplate',
 }
+PLATFORM_SPECIFIC_TAG = 'platform-specific'
+TAG_ANNOTATION = 'Tag'
 
 CLASS_DECL_RE = re.compile(r'\b(?:class|interface|object)\s+([A-Za-z_]\w*)\b')
 IDENTIFIER_RE = re.compile(r'[A-Za-z_]\w*')
@@ -216,7 +218,7 @@ def parse_annotation(text: str, index: int, limit: int) -> tuple[tuple[str, str 
         arguments = text[annotation_end + 1:closing]
         annotation_end = closing + 1
 
-    value = extract_annotation_string(arguments) if simple_name == 'DisplayName' else None
+    value = extract_annotation_string(arguments) if simple_name in {'DisplayName', TAG_ANNOTATION} else None
     return (simple_name, value), annotation_end
 
 
@@ -260,6 +262,10 @@ def has_test_annotation(annotations: list[tuple[str, str | None]]) -> bool:
     return any(name in TEST_ANNOTATIONS for name, _value in annotations)
 
 
+def has_platform_specific_tag(annotations: list[tuple[str, str | None]]) -> bool:
+    return any(name == TAG_ANNOTATION and value == PLATFORM_SPECIFIC_TAG for name, value in annotations)
+
+
 def parse_method_name(declaration: str) -> str | None:
     match = re.search(r'\bfun\s+([A-Za-z_]\w*)\s*\(', declaration)
     if match is None:
@@ -272,7 +278,7 @@ def skip_line(text: str, index: int, limit: int) -> int:
     return limit if newline == -1 else newline + 1
 
 
-def find_top_level_class(text: str) -> tuple[str, str, int, int] | None:
+def find_top_level_class(text: str) -> tuple[str, str, bool, int, int] | None:
     index = 0
     limit = len(text)
     depth = 0
@@ -323,7 +329,8 @@ def find_top_level_class(text: str) -> tuple[str, str, int, int] | None:
             class_close = find_matching(text, terminator_index, '{', '}', limit)
             if class_close is None:
                 return None
-            return class_name, class_display_name, terminator_index, class_close
+            is_platform_specific = has_platform_specific_tag(pending_annotations)
+            return class_name, class_display_name, is_platform_specific, terminator_index, class_close
 
         pending_annotations.clear()
         if terminator is None:
@@ -344,7 +351,9 @@ def parse_suite_tests(
     if parsed_class is None:
         return []
 
-    _class_name, suite_name, class_open, class_close = parsed_class
+    _class_name, suite_name, is_platform_specific, class_open, class_close = parsed_class
+    if cross_platform and is_platform_specific:
+        return []
     suite_tests: list[tuple[str, str]] = []
     base_filename = Path(path).name
     suite_title = f'{suite_name}:'
@@ -379,7 +388,11 @@ def parse_suite_tests(
             continue
 
         declaration, terminator, terminator_index = collect_declaration(text, index, class_close)
-        if terminator == '{' and has_test_annotation(pending_annotations):
+        if (
+            terminator == '{'
+            and has_test_annotation(pending_annotations)
+            and not (cross_platform and has_platform_specific_tag(pending_annotations))
+        ):
             method_name = parse_method_name(declaration)
             if method_name is not None:
                 test_name = annotation_value(pending_annotations, 'DisplayName') or method_name

--- a/scripts/ui-test-list-diff
+++ b/scripts/ui-test-list-diff
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 
+import argparse
 import difflib
 import subprocess
 import sys
 from pathlib import Path
 
 
-def ui_test_list(ref: str) -> list[str]:
+def ui_test_list(ref: str, *, cross_platform: bool = False) -> list[str]:
     script = Path(__file__).with_name('ui-test-list')
+    command = [sys.executable, str(script)]
+    if cross_platform:
+        command.append('--cross-platform')
+    command.append(ref)
     result = subprocess.run(
-        [sys.executable, str(script), ref],
+        command,
         check=True,
         capture_output=True,
         text=True,
@@ -90,22 +95,29 @@ def suite_aware_unified_diff(
     return diff_lines
 
 
-def main() -> int:
-    if len(sys.argv) != 3:
-        print(f'Usage: {sys.argv[0]} <base-ref> <head-ref>', file=sys.stderr)
-        return 1
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Show UI test list changes.')
+    parser.add_argument('base_ref', help='Base git ref to compare')
+    parser.add_argument('head_ref', help='Head git ref to compare')
+    parser.add_argument(
+        '--cross-platform',
+        action='store_true',
+        help='Forward --cross-platform to ui-test-list for normalized suite headings',
+    )
+    return parser.parse_args()
 
-    base_ref = sys.argv[1]
-    head_ref = sys.argv[2]
-    base_lines = ui_test_list(base_ref)
-    head_lines = ui_test_list(head_ref)
+
+def main() -> int:
+    args = parse_args()
+    base_lines = ui_test_list(args.base_ref, cross_platform=args.cross_platform)
+    head_lines = ui_test_list(args.head_ref, cross_platform=args.cross_platform)
 
     diff = ''.join(
         suite_aware_unified_diff(
             base_lines,
             head_lines,
-            fromfile=f'{base_ref} test-list',
-            tofile=f'{head_ref} test-list',
+            fromfile=f'{args.base_ref} test-list',
+            tofile=f'{args.head_ref} test-list',
             n=1,
         )
     )


### PR DESCRIPTION
### Motivation
- Provide a cross-platform friendly output mode for `scripts/ui-test-list` where suite headings do not include source filenames.
- Make the option available from the CLI so callers (including diffs and cross-repo tooling) can opt into filename-free suite headings.

### Description
- Add `argparse`-based CLI handling and a new `--cross-platform` boolean flag to `scripts/ui-test-list`.
- Thread the `cross_platform` option through `suite_test_list` and `parse_suite_tests` so suite headings are emitted as `"<Suite>:"` when enabled and `"<Suite> [<file>.kt]:"` by default.
- Adjust function signatures for `parse_suite_tests` and `suite_test_list` and update the main entry to call `suite_test_list(args.ref, args.cross_platform)`.

### Testing
- Compiled the script with `python3 -m py_compile scripts/ui-test-list` and it succeeded.
- Verified normal and cross-platform outputs with `scripts/ui-test-list HEAD >/tmp/ui-test-list-normal.txt` and `scripts/ui-test-list --cross-platform HEAD >/tmp/ui-test-list-cross.txt`, and checked the presence/absence of `[...] .kt` filename markers with `rg`, which passed.
- Ran the project checks with `./gradlew check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f7966b9d88321aeebb5c0f1703818)